### PR TITLE
fix: correct broken Bun dev script path

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:e2e": "bun test tests/story-workflow.e2e.test.ts tests/opencode-real.e2e.test.ts",
     "test:e2e:real": "WORKFLOW_MANAGER_REAL_OPENCODE=1 bun test tests/opencode-real.e2e.test.ts",
     "test": "bun test",
-    "dev": "bun run src/index.ts",
+    "dev": "bun run ./src/index.ts",
     "supabase:start": "supabase start",
     "supabase:stop": "supabase stop",
     "supabase:status": "supabase status",


### PR DESCRIPTION
## Summary
Fixes #4 by correcting the Bun dev script invocation.

- Changed `package.json` script:
  - from: `bun run src/index.ts`
  - to: `bun run ./src/index.ts`

This allows `bun run dev ...` to execute the CLI entrypoint instead of failing with `Script not found "src/index.ts"`.

## Validation
Executed on branch `fix/issue-4-dev-script`:

- `bun install`
- `bun run dev run ./example-workflow.json --auto-confirm-all`
  - Command now executes successfully and returns a JSON run result.
- `bun run test:unit`
- `bun run build`

All commands passed.
