### PR TITLE
fix: enforce required step fields in workflow validation

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -69,12 +69,38 @@ export function validateWorkflow(def: WorkflowDefinition): string[] {
   const errors: string[] = [];
   const seen = new Set<string>();
 
+  if (!def.key.trim()) {
+    errors.push("Workflow key is required");
+  }
+
+  if (!def.title.trim()) {
+    errors.push("Workflow title is required");
+  }
+
+  if (!Array.isArray(def.steps) || def.steps.length === 0) {
+    errors.push("Workflow must define at least one step");
+    return errors;
+  }
+
   for (const step of def.steps) {
+    if (!step.key || !step.key.trim()) {
+      errors.push("Each step must define a non-empty key");
+      continue;
+    }
+
     if (seen.has(step.key)) errors.push(`Duplicate step key: ${step.key}`);
     seen.add(step.key);
 
     if (!["task", "approval", "system"].includes(step.kind)) {
       errors.push(`Invalid step kind for ${step.key}: ${step.kind}`);
+    }
+
+    if (step.kind === "task" && !step.taskSpec) {
+      errors.push(`Task step ${step.key} is missing taskSpec`);
+    }
+
+    if (step.kind === "approval" && !step.approvalSpec) {
+      errors.push(`Approval step ${step.key} is missing approvalSpec`);
     }
 
     for (const dep of step.dependsOn ?? []) {

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -87,4 +87,44 @@ steps:
     expect(parseWorkflowFile(jsonFile).key).toBe("auto-json");
     expect(parseWorkflowFile(mdFile).key).toBe("auto-md");
   });
+
+  it("rejects steps missing required key", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wm-"));
+    const file = path.join(dir, "invalid-step-key.json");
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        key: "invalid-missing-step-key",
+        title: "Invalid Workflow",
+        steps: [
+          {
+            kind: "task",
+            dependsOn: [],
+            taskSpec: { adapterKey: "mock", payload: { mockResult: "success" } },
+          },
+        ],
+      }),
+      "utf-8"
+    );
+
+    const wf = parseWorkflowJson(file);
+    const errors = validateWorkflow(wf);
+    expect(errors).toContain("Each step must define a non-empty key");
+  });
+
+  it("rejects task steps without taskSpec", () => {
+    const wf = {
+      key: "invalid-task-spec",
+      title: "Invalid task spec",
+      steps: [
+        {
+          key: "s1",
+          kind: "task",
+        },
+      ],
+    } as unknown as ReturnType<typeof parseWorkflowJson>;
+
+    const errors = validateWorkflow(wf);
+    expect(errors).toContain("Task step s1 is missing taskSpec");
+  });
 });


### PR DESCRIPTION
## Summary
Fixes #5 by tightening workflow validation for required fields.

Changes:
- `src/parser.ts`
  - Require workflow-level fields to be non-empty (`key`, `title`).
  - Require at least one step.
  - Require each step to have a non-empty `key`.
  - Require `taskSpec` for `task` steps.
  - Require `approvalSpec` for `approval` steps.
- `tests/parser.test.ts`
  - Added regression test for missing step key.
  - Added test for task step missing `taskSpec`.

## Validation
Executed on branch `fix/issue-5-step-validation`:

- `bun test tests/parser.test.ts`
  - New tests pass.
- Repro now fails as expected:
  - `bun src/index.ts validate ./tmp-invalid-missing-step-key.json`
  - Output includes: `Each step must define a non-empty key`
  - Exit code: `1`
- `bun run test:unit`
- `bun run build`

All commands passed.
