### PR TITLE
fix: align waiting-for-approval run event semantics

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -171,7 +171,7 @@ export function runWorkflow(definition: WorkflowDefinition, options?: RunOptions
         { reason: confirmation.reason, validation: requiresValidation(step) },
         step.key
       );
-      eventLog.push(runId, "run.cancelled", { reason: "confirmation required" }, step.key, actor);
+      eventLog.push(runId, "run.waiting_for_approval", { reason: "confirmation required" }, step.key, actor);
       break;
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -145,6 +145,7 @@ export interface RunEvent {
   type:
     | "run.created"
     | "run.started"
+    | "run.waiting_for_approval"
     | "step.runnable"
     | "step.claimed"
     | "step.execution_started"

--- a/tests/engine.test.ts
+++ b/tests/engine.test.ts
@@ -87,5 +87,7 @@ describe("engine routing", () => {
     const result = runWorkflow(wf);
     expect(result.status).toBe("waiting_for_approval");
     expect(result.events.some((e) => e.type === "step.waiting_for_approval")).toBe(true);
+    expect(result.events.some((e) => e.type === "run.waiting_for_approval")).toBe(true);
+    expect(result.events.some((e) => e.type === "run.cancelled")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
Fixes #6 by aligning run lifecycle events with `waiting_for_approval` semantics.

Changes:
- `src/engine.ts`
  - On missing confirmation, emit `run.waiting_for_approval` instead of `run.cancelled`.
- `src/types.ts`
  - Added `run.waiting_for_approval` to `RunEvent.type` union.
- `tests/engine.test.ts`
  - Added assertions that:
    - `run.waiting_for_approval` is present.
    - `run.cancelled` is not emitted in this pause path.

## Validation
Executed on branch `fix/issue-6-event-semantics`:

- `bun test tests/engine.test.ts`
- `bun src/index.ts run ./example-workflow.json`
  - Top-level status: `waiting_for_approval`
  - Events contain `run.waiting_for_approval`
  - Events do not contain `run.cancelled`
- `bun run test:unit`
- `bun run build`

All commands passed.
