### PR TITLE
feat: add dashboard workflow publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ workflow-manager auth logout
 workflow-manager remote info alice/remote-bunny
 ```
 
+The deployed registry dashboard also supports browser-based token creation, workflow publishing, and creator analytics.
+
+Current dashboard capabilities include:
+
+- creator workflow analytics
+- token list and revoke controls
+- browser-based workflow publishing for JSON and Markdown sources
+
 ## Contribution
 
 - Keep workflow contracts backward-compatible when possible (`src/types.ts`)

--- a/apps/remote-registry/src/App.tsx
+++ b/apps/remote-registry/src/App.tsx
@@ -4,6 +4,7 @@ import { AuthProvider } from "./auth/AuthContext";
 import { AuthPage } from "./pages/AuthPage";
 import { DashboardPage } from "./pages/DashboardPage";
 import { HomePage } from "./pages/HomePage";
+import { PublishWorkflowPage } from "./pages/PublishWorkflowPage";
 import { SearchPage } from "./pages/SearchPage";
 import { TokensPage } from "./pages/TokensPage";
 import { WorkflowDetailPage } from "./pages/WorkflowDetailPage";
@@ -23,6 +24,7 @@ function App() {
               <Route path="/workflow/:owner/:slug" element={<WorkflowDetailPage />} />
               <Route path="/auth" element={<AuthPage />} />
               <Route path="/dashboard" element={<DashboardPage />} />
+              <Route path="/dashboard/publish" element={<PublishWorkflowPage />} />
               <Route path="/dashboard/tokens" element={<TokensPage />} />
               <Route path="*" element={<Navigate to="/" replace />} />
             </Route>

--- a/apps/remote-registry/src/index.css
+++ b/apps/remote-registry/src/index.css
@@ -37,7 +37,9 @@ a {
 }
 
 button,
-input {
+input,
+select,
+textarea {
   font: inherit;
 }
 
@@ -50,12 +52,19 @@ button {
   cursor: pointer;
 }
 
-input {
+input,
+select,
+textarea {
   width: 100%;
   border: 1px solid var(--border);
   border-radius: 0.85rem;
   padding: 0.85rem 1rem;
   background: var(--surface-strong);
+}
+
+textarea {
+  min-height: 18rem;
+  resize: vertical;
 }
 
 code,
@@ -163,6 +172,18 @@ pre {
   top: 1rem;
 }
 
+.publish-grid {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 1rem;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
 .workflow-card__header,
 .meta-row {
   display: flex;
@@ -259,6 +280,11 @@ pre {
 
 @media (max-width: 900px) {
   .feature-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .publish-grid,
+  .form-grid {
     grid-template-columns: 1fr;
   }
 

--- a/apps/remote-registry/src/lib/remoteApi.ts
+++ b/apps/remote-registry/src/lib/remoteApi.ts
@@ -1,5 +1,6 @@
 import { getSupabasePublishableKey, getSupabaseUrl } from "./env";
-import type { CliTokenListResponse, RemoteProfile, SearchResponse, TokenSummary, WorkflowAnalyticsResponse, WorkflowDetail } from "../types";
+import type { CliTokenListResponse, PublishedWorkflowResponse, RemoteProfile, SearchResponse, TokenSummary, WorkflowAnalyticsResponse, WorkflowDetail } from "../types";
+import type { WorkflowDefinitionInput } from "./workflowSource";
 
 async function callFunction<T>(path: string, init: RequestInit = {}): Promise<T> {
   const response = await fetch(`${getSupabaseUrl()}/functions/v1/${path}`, {
@@ -77,5 +78,30 @@ export function fetchWorkflowAnalytics(accessToken: string): Promise<WorkflowAna
     headers: {
       Authorization: `Bearer ${accessToken}`,
     },
+  });
+}
+
+export function publishWorkflow(
+  accessToken: string,
+  body: {
+    slug: string;
+    title: string;
+    description?: string | null;
+    visibility: "public" | "private";
+    versionLabel: string;
+    sourceFormat: "markdown" | "json";
+    rawSource: string;
+    definition: WorkflowDefinitionInput;
+    tags?: string[];
+    changelog?: string | null;
+    publishedState: "draft" | "published";
+  }
+): Promise<PublishedWorkflowResponse> {
+  return callFunction<PublishedWorkflowResponse>("publish-workflow", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify(body),
   });
 }

--- a/apps/remote-registry/src/lib/workflowSource.ts
+++ b/apps/remote-registry/src/lib/workflowSource.ts
@@ -1,0 +1,174 @@
+function parseScalar(value: string): unknown {
+  const trimmed = value.trim();
+  if (trimmed === "true") return true;
+  if (trimmed === "false") return false;
+  if (trimmed === "null") return null;
+  if (/^-?\d+(?:\.\d+)?$/.test(trimmed)) return Number(trimmed);
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function parseInlineArray(value: string): unknown[] {
+  const inner = value.trim().slice(1, -1).trim();
+  if (!inner) return [];
+  return inner.split(",").map((entry) => parseScalar(entry));
+}
+
+function parseSimpleYamlFrontmatter(frontmatter: string): Record<string, unknown> {
+  const root: Record<string, unknown> = {};
+  const lines = frontmatter.split(/\r?\n/);
+  const stack: Array<{ indent: number; value: Record<string, unknown> | unknown[] }> = [{ indent: -1, value: root }];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const rawLine = lines[index];
+    if (!rawLine.trim()) continue;
+    const indent = rawLine.match(/^\s*/)?.[0].length ?? 0;
+    const line = rawLine.trim();
+
+    while (stack.length > 1 && indent <= stack[stack.length - 1].indent) {
+      stack.pop();
+    }
+
+    const parent = stack[stack.length - 1].value;
+    if (line.startsWith("- ")) {
+      if (!Array.isArray(parent)) {
+        throw new Error("Invalid frontmatter structure: list item without array parent");
+      }
+
+      const itemContent = line.slice(2).trim();
+      if (!itemContent) {
+        const newItem: Record<string, unknown> = {};
+        parent.push(newItem);
+        stack.push({ indent, value: newItem });
+        continue;
+      }
+
+      if (itemContent.includes(":")) {
+        const [rawKey, ...rawRest] = itemContent.split(":");
+        const key = rawKey.trim();
+        const rest = rawRest.join(":").trim();
+        const item: Record<string, unknown> = {};
+        if (rest) {
+          item[key] = rest.startsWith("[") && rest.endsWith("]") ? parseInlineArray(rest) : parseScalar(rest);
+        } else {
+          item[key] = {};
+        }
+        parent.push(item);
+        stack.push({ indent, value: item });
+        if (!rest) {
+          stack.push({ indent: indent + 2, value: item[key] as Record<string, unknown> });
+        }
+      } else {
+        parent.push(parseScalar(itemContent));
+      }
+      continue;
+    }
+
+    const [rawKey, ...rawRest] = line.split(":");
+    const key = rawKey.trim();
+    const rest = rawRest.join(":").trim();
+    if (!key || Array.isArray(parent)) {
+      throw new Error("Invalid frontmatter structure");
+    }
+
+    if (!rest) {
+      const nextLine = lines[index + 1]?.trim() ?? "";
+      const container: Record<string, unknown> | unknown[] = nextLine.startsWith("-") ? [] : {};
+      parent[key] = container;
+      stack.push({ indent, value: container });
+      continue;
+    }
+
+    parent[key] = rest.startsWith("[") && rest.endsWith("]") ? parseInlineArray(rest) : parseScalar(rest);
+  }
+
+  return root;
+}
+
+function parseMarkdownDefinition(rawSource: string): WorkflowDefinitionInput {
+  const trimmed = rawSource.trimStart();
+  if (!trimmed.startsWith("---")) {
+    throw new Error("Markdown workflow source must begin with YAML frontmatter");
+  }
+
+  const parts = trimmed.split(/^---\s*$/m);
+  if (parts.length < 3) {
+    throw new Error("Markdown workflow source must contain opening and closing frontmatter fences");
+  }
+
+  const frontmatter = parts[1] ?? "";
+  return validateDefinition(parseSimpleYamlFrontmatter(frontmatter));
+}
+
+export interface WorkflowDefinitionInput {
+  key: string;
+  title: string;
+  description?: string;
+  objectives?: string[];
+  inputSchema?: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+  defaultRetryPolicy?: {
+    maxAttempts: number;
+  };
+  steps: Array<Record<string, unknown>>;
+}
+
+export interface ParsedWorkflowSource {
+  definition: WorkflowDefinitionInput;
+  sourceFormat: "markdown" | "json";
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function validateDefinition(value: unknown): WorkflowDefinitionInput {
+  const definition = asRecord(value);
+  const key = typeof definition.key === "string" ? definition.key.trim() : "";
+  const title = typeof definition.title === "string" ? definition.title.trim() : "";
+  const steps = Array.isArray(definition.steps) ? definition.steps : [];
+
+  if (!key || !title || !Array.isArray(definition.steps)) {
+    throw new Error("Workflow source must include key, title, and steps");
+  }
+
+  return {
+    ...definition,
+    key,
+    title,
+    description: typeof definition.description === "string" ? definition.description : undefined,
+    objectives: Array.isArray(definition.objectives) ? definition.objectives.filter((item): item is string => typeof item === "string") : undefined,
+    inputSchema: asRecord(definition.inputSchema),
+    outputSchema: asRecord(definition.outputSchema),
+    defaultRetryPolicy: asRecord(definition.defaultRetryPolicy).maxAttempts
+      ? { maxAttempts: Number(asRecord(definition.defaultRetryPolicy).maxAttempts) }
+      : undefined,
+    steps,
+  } as WorkflowDefinitionInput;
+}
+
+export function detectSourceFormat(rawSource: string): "markdown" | "json" {
+  const trimmed = rawSource.trim();
+  return trimmed.startsWith("{") ? "json" : "markdown";
+}
+
+export function parseWorkflowSource(rawSource: string, explicitFormat?: "markdown" | "json"): ParsedWorkflowSource {
+  const sourceFormat = explicitFormat ?? detectSourceFormat(rawSource);
+  if (sourceFormat === "json") {
+    try {
+      return {
+        sourceFormat,
+        definition: validateDefinition(JSON.parse(rawSource)),
+      };
+    } catch (error) {
+      throw new Error(`Invalid JSON workflow source: ${(error as Error).message}`);
+    }
+  }
+
+  return {
+    sourceFormat,
+    definition: parseMarkdownDefinition(rawSource),
+  };
+}

--- a/apps/remote-registry/src/pages/DashboardPage.tsx
+++ b/apps/remote-registry/src/pages/DashboardPage.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Navigate } from "react-router-dom";
+import { Link, Navigate } from "react-router-dom";
 import { useAuth } from "../auth/AuthContext";
 import { fetchWhoAmI, fetchWorkflowAnalytics } from "../lib/remoteApi";
 
@@ -48,6 +48,10 @@ export function DashboardPage() {
       <div className="panel">
         <h3>CLI handoff</h3>
         <code>{cliSnippet}</code>
+        <div className="meta-row">
+          <Link to="/dashboard/publish">Publish from the dashboard</Link>
+          <Link to="/dashboard/tokens">Manage CLI tokens</Link>
+        </div>
       </div>
 
       <div className="panel">
@@ -88,6 +92,10 @@ export function DashboardPage() {
                 </div>
               </div>
               <code>{`workflow-manager pull ${profile.data?.username ?? "owner"}/${item.slug}`}</code>
+              <div className="meta-row">
+                <Link to={`/workflow/${profile.data?.username ?? "owner"}/${item.slug}`}>Open detail page</Link>
+                <Link to="/dashboard/publish">Publish a new version</Link>
+              </div>
             </article>
           ))}
         </div>

--- a/apps/remote-registry/src/pages/PublishWorkflowPage.tsx
+++ b/apps/remote-registry/src/pages/PublishWorkflowPage.tsx
@@ -1,0 +1,191 @@
+import { type FormEvent, useMemo, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Navigate, Link } from "react-router-dom";
+import { useAuth } from "../auth/AuthContext";
+import { publishWorkflow } from "../lib/remoteApi";
+import { parseWorkflowSource } from "../lib/workflowSource";
+
+const starterSource = `{
+  "key": "workflow-key",
+  "title": "Workflow Title",
+  "steps": [
+    {
+      "key": "first_step",
+      "kind": "task",
+      "taskSpec": {
+        "adapterKey": "mock",
+        "payload": {
+          "mockResult": "success"
+        }
+      }
+    }
+  ]
+}`;
+
+function slugify(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 63);
+}
+
+export function PublishWorkflowPage() {
+  const { loading, session } = useAuth();
+  const queryClient = useQueryClient();
+  const [rawSource, setRawSource] = useState(starterSource);
+  const [description, setDescription] = useState("Published from the remote registry dashboard");
+  const [visibility, setVisibility] = useState<"public" | "private">("public");
+  const [versionLabel, setVersionLabel] = useState("v1");
+  const [tags, setTags] = useState("example,dashboard");
+  const [changelog, setChangelog] = useState("Initial dashboard publish");
+  const [publishedState, setPublishedState] = useState<"draft" | "published">("published");
+  const [error, setError] = useState<string | null>(null);
+
+  const parsed = useMemo(() => {
+    try {
+      return parseWorkflowSource(rawSource);
+    } catch {
+      return null;
+    }
+  }, [rawSource]);
+
+  const publishMutation = useMutation({
+    mutationFn: async () => {
+      if (!session) {
+        throw new Error("You must be signed in to publish a workflow");
+      }
+      const parsedSource = parseWorkflowSource(rawSource);
+      return publishWorkflow(session.access_token, {
+        slug: slugify(parsedSource.definition.key),
+        title: parsedSource.definition.title,
+        description,
+        visibility,
+        versionLabel,
+        sourceFormat: parsedSource.sourceFormat,
+        rawSource,
+        definition: parsedSource.definition,
+        tags: tags.split(",").map((tag) => tag.trim().toLowerCase()).filter(Boolean),
+        changelog,
+        publishedState,
+      });
+    },
+    onSuccess() {
+      void queryClient.invalidateQueries({ queryKey: ["workflow-analytics", session?.access_token] });
+      setError(null);
+    },
+    onError(mutationError) {
+      setError((mutationError as Error).message);
+    },
+  });
+
+  if (loading) {
+    return <section className="panel">Checking session...</section>;
+  }
+
+  if (!session) {
+    return <Navigate to="/auth" replace />;
+  }
+
+  return (
+    <section className="stack page-grid">
+      <div className="panel">
+        <p className="eyebrow">Publish workflow</p>
+        <h2>Publish a registry workflow</h2>
+        <p>Paste a JSON or Markdown workflow definition. The app parses it, extracts the workflow metadata, and publishes the raw source.</p>
+      </div>
+
+      <div className="publish-grid">
+        <form
+          className="panel stack"
+          onSubmit={(event: FormEvent<HTMLFormElement>) => {
+            event.preventDefault();
+            void publishMutation.mutateAsync();
+          }}
+        >
+          <label className="stack compact">
+            <span>Description</span>
+            <input name="workflow-description" value={description} onChange={(event) => setDescription(event.target.value)} />
+          </label>
+          <div className="form-grid">
+            <label className="stack compact">
+              <span>Visibility</span>
+              <select value={visibility} onChange={(event) => setVisibility(event.target.value as "public" | "private")}> 
+                <option value="public">public</option>
+                <option value="private">private</option>
+              </select>
+            </label>
+            <label className="stack compact">
+              <span>Version label</span>
+              <input name="version-label" value={versionLabel} onChange={(event) => setVersionLabel(event.target.value)} />
+            </label>
+          </div>
+          <label className="stack compact">
+            <span>Tags</span>
+            <input name="workflow-tags" value={tags} onChange={(event) => setTags(event.target.value)} placeholder="example,dashboard" />
+          </label>
+          <label className="stack compact">
+            <span>Changelog</span>
+            <input name="workflow-changelog" value={changelog} onChange={(event) => setChangelog(event.target.value)} />
+          </label>
+          <label className="stack compact">
+            <span>Published state</span>
+            <select value={publishedState} onChange={(event) => setPublishedState(event.target.value as "draft" | "published")}> 
+              <option value="published">published</option>
+              <option value="draft">draft</option>
+            </select>
+          </label>
+          <label className="stack compact">
+            <span>Workflow source</span>
+            <textarea name="workflow-source" value={rawSource} onChange={(event) => setRawSource(event.target.value)} rows={22} />
+          </label>
+          <button type="submit" disabled={publishMutation.isPending}>
+            {publishMutation.isPending ? "Publishing workflow..." : "Publish workflow"}
+          </button>
+          {error && <div className="banner error">{error}</div>}
+          {publishMutation.data && (
+            <div className="banner success">
+              Published <strong>{publishMutation.data.slug}</strong> as {publishMutation.data.version}.{" "}
+              <Link to="/dashboard">Return to dashboard</Link>
+            </div>
+          )}
+        </form>
+
+        <aside className="panel stack">
+          <div>
+            <p className="eyebrow">Parsed preview</p>
+            <h3>{parsed?.definition.title ?? "Waiting for valid workflow"}</h3>
+            <p>{parsed ? `${parsed.definition.steps.length} steps detected` : "Fix the source to preview metadata."}</p>
+          </div>
+          {parsed && (
+            <>
+              <div className="stats-grid">
+                <div>
+                  <strong>{parsed.definition.key}</strong>
+                  <span>Workflow key</span>
+                </div>
+                <div>
+                  <strong>{parsed.sourceFormat}</strong>
+                  <span>Source format</span>
+                </div>
+                <div>
+                  <strong>{slugify(parsed.definition.key)}</strong>
+                  <span>Remote slug</span>
+                </div>
+              </div>
+              <div className="stack compact">
+                {parsed.definition.steps.map((step, index) => (
+                  <div key={`${String(step.key ?? index)}`} className="panel inset-panel">
+                    <strong>{String(step.key ?? `step-${index + 1}`)}</strong>
+                    <span className="eyebrow">{String(step.kind ?? "task")}</span>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </aside>
+      </div>
+    </section>
+  );
+}

--- a/apps/remote-registry/src/types.ts
+++ b/apps/remote-registry/src/types.ts
@@ -32,6 +32,19 @@ export interface WorkflowDetail {
   createdAt: string;
 }
 
+export interface PublishedWorkflowResponse {
+  namespaceId: string;
+  ownerUserId: string;
+  slug: string;
+  title: string;
+  visibility: string;
+  version: string;
+  sourceFormat: "markdown" | "json";
+  publishedState: string;
+  createdAt: string;
+  tags: string[];
+}
+
 export interface TokenSummary {
   tokenId: string;
   token?: string;

--- a/apps/remote-registry/src/ui/AppShell.tsx
+++ b/apps/remote-registry/src/ui/AppShell.tsx
@@ -15,6 +15,7 @@ export function AppShell() {
           <NavLink to="/">Overview</NavLink>
           <NavLink to="/search">Search</NavLink>
           <NavLink to="/dashboard">Dashboard</NavLink>
+          <NavLink to="/dashboard/publish">Publish</NavLink>
           <NavLink to="/dashboard/tokens">Tokens</NavLink>
           {!session && <NavLink to="/auth">Sign in</NavLink>}
           {session && (

--- a/doc/guide/getting-started.md
+++ b/doc/guide/getting-started.md
@@ -65,6 +65,18 @@ bun run remote-registry:build
 
 Set up browser env values in `apps/remote-registry/.env.local` using `apps/remote-registry/.env.example`.
 
+The web app now includes:
+
+- dashboard analytics for your published workflows
+- CLI token creation and revocation
+- browser-based workflow publishing for Markdown and JSON sources
+
+Primary routes:
+
+- `/dashboard`
+- `/dashboard/publish`
+- `/dashboard/tokens`
+
 ## Build a standalone binary
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:bin:windows": "bun build ./src/index.ts --compile --target bun-windows-x64 --outfile ./dist/workflow-manager-windows-x64.exe",
     "build:bin:all": "bun run build:bin:macos && bun run build:bin:linux && bun run build:bin:windows",
     "man": "man ./man/workflow-manager.1",
-    "test:unit": "bun test tests/parser.test.ts tests/engine.test.ts tests/mockExecutor.test.ts tests/opencodeExecutor.test.ts tests/remote.test.ts tests/supabase-functions.test.ts",
+    "test:unit": "bun test tests/parser.test.ts tests/engine.test.ts tests/mockExecutor.test.ts tests/opencodeExecutor.test.ts tests/remote.test.ts tests/supabase-functions.test.ts tests/remote-registry-app.test.ts",
     "test:e2e": "bun test tests/story-workflow.e2e.test.ts tests/opencode-real.e2e.test.ts",
     "test:e2e:real": "WORKFLOW_MANAGER_REAL_OPENCODE=1 bun test tests/opencode-real.e2e.test.ts",
     "test": "bun test",

--- a/tests/remote-registry-app.test.ts
+++ b/tests/remote-registry-app.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { detectSourceFormat, parseWorkflowSource } from "../apps/remote-registry/src/lib/workflowSource";
+
+describe("remote registry app workflow parsing", () => {
+  it("parses JSON workflow source for dashboard publishing", () => {
+    const parsed = parseWorkflowSource(
+      JSON.stringify({
+        key: "dashboard-demo",
+        title: "Dashboard Demo",
+        steps: [{ key: "plan", kind: "task", taskSpec: { adapterKey: "mock" } }],
+      })
+    );
+
+    expect(parsed.sourceFormat).toBe("json");
+    expect(parsed.definition.key).toBe("dashboard-demo");
+    expect(parsed.definition.steps).toHaveLength(1);
+  });
+
+  it("parses Markdown frontmatter workflow source for dashboard publishing", () => {
+    const parsed = parseWorkflowSource(`---
+key: dashboard-md
+title: Dashboard Markdown
+steps:
+  - key: plan
+    kind: task
+    taskSpec:
+      adapterKey: mock
+---
+
+# Notes
+`);
+
+    expect(parsed.sourceFormat).toBe("markdown");
+    expect(parsed.definition.title).toBe("Dashboard Markdown");
+  });
+
+  it("detects source format heuristically", () => {
+    expect(detectSourceFormat('{"key":"demo"}')).toBe("json");
+    expect(detectSourceFormat("---\nkey: demo\n")).toBe("markdown");
+  });
+});


### PR DESCRIPTION
## Summary
- add browser-based workflow publishing to the remote registry dashboard with JSON and Markdown source parsing
- expand the dashboard and navigation to connect analytics, token management, and publish flows in one place
- add parsing tests for the browser publishing path and update product docs

## Validation
- bun run test:unit
- bun run build
- bun run remote-registry:build
- bun run docs:build
- redeployed the updated app to https://workflow-manager-ui.netlify.app