### PR TITLE
ci: add PR/main checks workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,52 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: TypeScript Build
+            command: bun run build
+          - name: Unit Tests
+            command: bun run test:unit
+          - name: E2E Tests
+            command: bun run test:e2e
+          - name: Docs Build
+            command: bun run docs:build
+          - name: Remote Registry Build
+            command: bun run remote-registry:build
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run check
+        run: ${{ matrix.command }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -48,5 +48,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Install remote-registry dependencies
+        if: matrix.name == 'Remote Registry Build'
+        run: bun install --cwd apps/remote-registry --frozen-lockfile
+
       - name: Run check
         run: ${{ matrix.command }}


### PR DESCRIPTION
## What This PR Does
Adds a dedicated CI workflow at `.github/workflows/pr-checks.yml` so every pull request (and every push to `main`) runs the same baseline validation.

## Triggers
- `pull_request` targeting `main`
- `push` to `main`
- manual `workflow_dispatch`

## Checks Included
- `bun run build` (TypeScript build)
- `bun run test:unit` (unit/integration suite)
- `bun run test:e2e` (fixture-based e2e)
- `bun run docs:build` (docs build)
- `bun run remote-registry:build` (remote registry app build)

## Follow-up Fix in This PR
The remote-registry build check now installs app-local dependencies before build:
- `bun install --cwd apps/remote-registry --frozen-lockfile`

