### PR TITLE
chore: add CODEOWNERS for default review requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default reviewers for the entire repository
+* @raheed-web @navio


### PR DESCRIPTION
## Summary
- add a repo-level CODEOWNERS file at \.github/CODEOWNERS
- set default owners to @raheed-web and @navio for all paths

## Behavior
- new pull requests will automatically request review from both owners
