### PR TITLE
ci: switch Netlify auto-release to workflow-manager-ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,16 @@ bun run docs:build
 bun run docs:preview
 ```
 
+Docs are now treated as a manual Netlify release flow. Build `doc/.vitepress/dist` locally and deploy it manually when needed.
+
 Remote registry app:
 
 ```bash
 bun run remote-registry:dev
 bun run remote-registry:build
 ```
+
+`workflow-manager-ui` is the Netlify auto-release target. The root `netlify.toml` now builds `apps/remote-registry/` so connected Netlify Git deploys can produce preview deploys for PRs and production deploys from merges to `main`.
 
 Manual help:
 
@@ -138,12 +142,15 @@ Current dashboard capabilities include:
 - Update docs under `doc/` when changing schema or runtime behavior
 - Add or update tests in `tests/` when touching parser or engine logic
 
-Netlify documentation deployment is configured with `netlify.toml`:
+Netlify auto-release is configured for the UI in `netlify.toml`:
 
-- build command: `npm run docs:build`
-- publish directory: `doc/.vitepress/dist`
+- base directory: `apps/remote-registry`
+- build command: `bun run build`
+- publish directory: `dist`
+- PRs: Deploy Previews
+- `main`: Production deploys for `workflow-manager-ui`
 
-When this repository is connected to Netlify, these settings are applied automatically.
+The docs site is no longer the auto-release target and should be deployed manually.
 
 ## Release
 

--- a/apps/remote-registry/README.md
+++ b/apps/remote-registry/README.md
@@ -25,3 +25,12 @@ The app currently includes:
 - sign-in/sign-up page
 - dashboard shell
 - CLI token creation page
+
+## Netlify release
+
+The repository root `netlify.toml` is configured to auto-release this app on Netlify:
+
+- PRs -> Deploy Previews
+- merges to `main` -> production deploys for `workflow-manager-ui`
+
+This assumes the Netlify site is connected to the GitHub repository and uses the root config file.

--- a/doc/guide/getting-started.md
+++ b/doc/guide/getting-started.md
@@ -56,6 +56,8 @@ bun run docs:build
 bun run docs:preview
 ```
 
+The docs site is a manual release target. Build `doc/.vitepress/dist` and deploy it manually when needed.
+
 ## Run the remote registry app
 
 ```bash
@@ -64,6 +66,8 @@ bun run remote-registry:build
 ```
 
 Set up browser env values in `apps/remote-registry/.env.local` using `apps/remote-registry/.env.example`.
+
+`workflow-manager-ui` is now the Netlify auto-release target via the root `netlify.toml`. That enables Deploy Previews for PRs and production deploys for merges to `main` once the Netlify site is connected to the repository.
 
 The web app now includes:
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,26 @@
 [build]
-  command = "npm run docs:build"
-  publish = "doc/.vitepress/dist"
+  base = "apps/remote-registry"
+  command = "bun run build"
+  publish = "dist"
+
+[build.environment]
+  BUN_VERSION = "1.1.42"
+
+[context.production]
+  command = "bun run build"
+
+[context.deploy-preview]
+  command = "bun run build"
+
+[context.branch-deploy]
+  command = "bun run build"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
 
 [dev]
-  command = "npm run docs:dev"
+  command = "bun run dev"
   targetPort = 5173
   framework = "#custom"


### PR DESCRIPTION
## Summary
- repurpose the root `netlify.toml` so Netlify builds `apps/remote-registry` instead of the docs site
- keep docs as a manual release target and document the new split between UI auto-release and docs manual deploys
- align local `netlify dev` behavior with the UI app so connected Netlify Git deploys can provide previews for PRs and production deploys for merges to `main`

## Validation
- bun run build
- bun run docs:build
- VITE_SUPABASE_URL=... VITE_SUPABASE_PUBLISHABLE_KEY=... bun run build (from `apps/remote-registry`)