### PR TITLE
feat: rename the runner package and auto-publish it

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -31,6 +31,8 @@ jobs:
             command: bun run test:unit
           - name: E2E Tests
             command: bun run test:e2e
+          - name: Package Dry Run
+            command: npm pack --dry-run
           - name: Docs Build
             command: bun run docs:build
           - name: Remote Registry Build

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ CLI runner for in-memory and Markdown/JSON workflow orchestration.
 - `src/mockExecutor.ts`: mock step executor for simulation
 - `src/events.ts`: event sequencing/logging
 - `src/types.ts`: contracts and status enums
+- `apps/remote-registry/`: React + Vite remote registry app
+- `supabase/`: migrations, local stack config, and Edge Functions
+- `doc/`: VitePress documentation site
+- `skills/`: agent skills shipped inside the main npm package for TanStack Intent and compatible loaders
 
 ## Quick start
 
@@ -125,6 +129,24 @@ workflow-manager auth logout
 workflow-manager remote info alice/remote-bunny
 ```
 
+## Agent skills
+
+The published `workflow-manager` npm package now ships the CLI runner and the bundled agent skills together.
+
+- bundled skill: `skills/workflow-manager-cli/SKILL.md`
+- discovery keyword: `tanstack-intent`
+- install flow: install `workflow-manager`, then run `npx @tanstack/intent@latest list` and `npx @tanstack/intent@latest install`
+
+Example usage:
+
+```bash
+npm install workflow-manager
+npx @tanstack/intent@latest list
+npx @tanstack/intent@latest install
+```
+
+See `skills/README.md` for the packaged skill layout, TanStack Intent integration, and release checks.
+
 The deployed registry dashboard also supports browser-based token creation, workflow publishing, and creator analytics.
 
 Current dashboard capabilities include:
@@ -155,6 +177,7 @@ The docs site is no longer the auto-release target and should be deployed manual
 ## Release
 
 - Push a semantic tag like `v0.2.0` to trigger the GitHub Actions release workflow.
+- Publish the root npm package when you want the CLI runner and `skills/` bundle to ship together.
 - The workflow runs tests and build, then compiles binaries for:
   - macOS arm64: `workflow-manager-macos-arm64`
   - Linux x64: `workflow-manager-linux-x64`

--- a/package.json
+++ b/package.json
@@ -7,6 +7,12 @@
   "bin": {
     "workflow-manager": "dist/index.js"
   },
+  "files": [
+    "dist/",
+    "man/",
+    "skills/",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "build:bin": "bun build ./src/index.ts --compile --outfile ./dist/workflow-manager",
@@ -20,6 +26,8 @@
     "test:e2e:real": "WORKFLOW_MANAGER_REAL_OPENCODE=1 bun test tests/opencode-real.e2e.test.ts",
     "test": "bun test",
     "dev": "bun run ./src/index.ts",
+    "package:check": "npm pack --dry-run",
+    "prepack": "bun run build",
     "supabase:start": "supabase start",
     "supabase:stop": "supabase stop",
     "supabase:status": "supabase status",
@@ -35,7 +43,11 @@
     "workflow",
     "orchestration",
     "cli",
-    "atep"
+    "atep",
+    "agent-skills",
+    "claude-code",
+    "opencode",
+    "tanstack-intent"
   ],
   "license": "MIT",
   "dependencies": {

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,63 @@
+# workflow-manager skills
+
+`workflow-manager` now ships its TanStack Intent-compatible skills in the main npm package.
+
+The first bundled skill is `workflow-manager-cli`, which teaches agents how to:
+
+- design workflow definitions
+- scaffold Markdown or JSON workflows
+- validate and run workflows safely
+- authenticate against the remote registry
+- publish, search, and pull shared workflows
+
+## Install
+
+Install the main package in the project where you want the CLI and skill available:
+
+```bash
+npm install workflow-manager
+```
+
+Then use TanStack Intent to discover and map the shipped skill into your agent configuration:
+
+```bash
+npx @tanstack/intent@latest list
+npx @tanstack/intent@latest install
+```
+
+Intent writes task-to-skill mappings into `AGENTS.md`-style config files and points them at the installed package path under `node_modules/workflow-manager/skills/...`.
+
+## Packaged skill
+
+- skill path: `skills/workflow-manager-cli/SKILL.md`
+- package keyword: `tanstack-intent`
+- published with: the root `workflow-manager` npm package
+
+## Local development
+
+From the repository root:
+
+```bash
+npm pack --dry-run
+ls skills/workflow-manager-cli
+```
+
+## Publish
+
+Publish from the repository root so the CLI runner and `skills/` ship together:
+
+```bash
+npm publish
+```
+
+Before publishing, verify the package contents:
+
+```bash
+npm pack --dry-run
+```
+
+## Package layout
+
+- `skills/workflow-manager-cli/SKILL.md`: TanStack Intent skill entrypoint
+- `skills/workflow-manager-cli/README.md`: local notes for contributors
+- `package.json`: package metadata, published files, and `tanstack-intent` keyword

--- a/skills/workflow-manager-cli/README.md
+++ b/skills/workflow-manager-cli/README.md
@@ -1,0 +1,11 @@
+# workflow-manager-cli skill
+
+This skill ships inside the root `workflow-manager` npm package.
+
+It is designed for TanStack Intent discovery and should stay aligned with the CLI behavior documented in:
+
+- `README.md`
+- `src/index.ts`
+- `src/parser.ts`
+- `src/engine.ts`
+- `src/remote/commands.ts`

--- a/skills/workflow-manager-cli/SKILL.md
+++ b/skills/workflow-manager-cli/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: workflow-manager/workflow-manager-cli
+description: >
+  Load this skill when working with the workflow-manager CLI, authoring or
+  validating workflow definitions, configuring step skills and adapters, or
+  publishing workflows to the remote registry. Covers questions, scaffold,
+  validate, run, auth, publish, pull, search, and remote info.
+type: core
+library: workflow-manager
+library_version: "0.1.0"
+sources:
+  - "alnavarro/workflow-manager:README.md"
+  - "alnavarro/workflow-manager:src/index.ts"
+  - "alnavarro/workflow-manager:src/parser.ts"
+  - "alnavarro/workflow-manager:src/engine.ts"
+  - "alnavarro/workflow-manager:src/remote/commands.ts"
+---
+
+# workflow-manager CLI
+
+Use this skill when you need to create or operate `workflow-manager` workflows from the terminal.
+
+## When to use this skill
+
+Use it when the user wants to:
+
+- scaffold a new workflow definition
+- validate or run a workflow file
+- configure approvals, retry policy, or adapter initialization
+- publish a workflow to the remote registry
+- search for or pull a shared workflow
+- understand the difference between Markdown and JSON workflow formats
+
+## Core workflow
+
+Use this sequence unless the user asks for a narrower task:
+
+1. Discover the workflow intent with `workflow-manager questions`
+2. Scaffold a starter file with `workflow-manager scaffold`
+3. Edit the workflow definition
+4. Validate the file with `workflow-manager validate`
+5. Execute it with `workflow-manager run`
+6. If needed, authenticate and publish with the remote registry commands
+
+## Local workflow commands
+
+```bash
+workflow-manager questions
+
+workflow-manager scaffold ./example-workflow.md
+workflow-manager scaffold ./example-workflow.json --format json
+
+workflow-manager validate ./example-workflow.md
+workflow-manager validate ./example-workflow.json
+
+workflow-manager run ./example-workflow.md --confirm discover,qa_gate:human
+workflow-manager run ./example-workflow.json --auto-confirm-all
+```
+
+## Remote registry commands
+
+```bash
+workflow-manager auth login --token <token>
+workflow-manager auth whoami
+workflow-manager auth logout
+
+workflow-manager search bunny
+workflow-manager remote info alice/remote-bunny
+workflow-manager publish ./example-workflow.json --visibility public --tag storytelling,example
+workflow-manager pull alice/remote-bunny --output ./remote-bunny.json
+```
+
+## Skill guidance
+
+- Prefer `validate` before `run` or `publish`
+- Keep `runWorkflow(...)` behavior registry-agnostic; registry operations belong in the CLI remote commands
+- Use Markdown workflows when the user wants editable frontmatter plus notes
+- Use JSON workflows when the user wants machine-generated or strongly structured files
+- Use `--auto-confirm-all` only when the workflow is intentionally non-interactive
+- When publishing, preserve the source format the user authored
+
+## Workflow authoring checklist
+
+- Set stable `key` and `title` values
+- Define clear step `objective` text
+- Add `dependsOn` relationships explicitly
+- Set validation mode per step (`none`, `human`, `external`)
+- Configure adapter initialization under `taskSpec.init`
+- Use stable step keys because tests and docs may refer to them
+
+## Adapter and validation notes
+
+- Supported adapters include `mock`, `opencode`, `codex`, and `claude-code`
+- Human approvals should stay explicit in workflow definitions
+- External validation should be deterministic where possible
+- Use the mock adapter for fast tests and scaffolding flows
+
+## Recommended project references
+
+- `src/index.ts`: CLI command entrypoint
+- `src/parser.ts`: Markdown and JSON parsing plus validation
+- `src/engine.ts`: orchestration loop
+- `src/remote/commands.ts`: auth, publish, pull, search, and remote info commands
+- `tests/`: unit and e2e coverage for workflow behavior
+
+## Typical troubleshooting
+
+- If validation fails, inspect the reported schema or dependency error before running again
+- If `publish` fails, confirm the user is logged in with `workflow-manager auth whoami`
+- If remote calls fail in the browser, verify the remote registry app has valid Supabase `VITE_*` environment variables
+- If a real adapter test fails, confirm the underlying external CLI is installed and available on `PATH`

--- a/skills/workflow-manager-cli/SKILL.md
+++ b/skills/workflow-manager-cli/SKILL.md
@@ -9,11 +9,11 @@ type: core
 library: workflow-manager
 library_version: "0.1.0"
 sources:
-  - "alnavarro/workflow-manager:README.md"
-  - "alnavarro/workflow-manager:src/index.ts"
-  - "alnavarro/workflow-manager:src/parser.ts"
-  - "alnavarro/workflow-manager:src/engine.ts"
-  - "alnavarro/workflow-manager:src/remote/commands.ts"
+  - "navio/workflow-manager:README.md"
+  - "navio/workflow-manager:src/index.ts"
+  - "navio/workflow-manager:src/parser.ts"
+  - "navio/workflow-manager:src/engine.ts"
+  - "navio/workflow-manager:src/remote/commands.ts"
 ---
 
 # workflow-manager CLI


### PR DESCRIPTION
## Summary
- rename the npm package to `@workflow-manager/runner` and expose the CLI as `wfm`
- update docs, man page, release artifact names, and TanStack Intent skill metadata for the new package/bin names
- publish `@workflow-manager/runner` automatically on merges to `main` when runner package files change and the version is unpublished

## Notes
- the npm publish workflow expects a repository `NPM_TOKEN` secret with publish access to the `@workflow-manager` scope
- the workflow skips duplicate publishes, so PRs still need a `package.json` version bump for each npm release