### PR TITLE
feat: claude-code executor with streaming output and interactive approval gates

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:bin:windows": "bun build ./src/index.ts --compile --target bun-windows-x64 --outfile ./dist/workflow-manager-windows-x64.exe",
     "build:bin:all": "bun run build:bin:macos && bun run build:bin:linux && bun run build:bin:windows",
     "man": "man ./man/workflow-manager.1",
-    "test:unit": "bun test tests/parser.test.ts tests/engine.test.ts tests/mockExecutor.test.ts tests/opencodeExecutor.test.ts tests/remote.test.ts tests/run-telemetry.test.ts tests/supabase-functions.test.ts tests/supabase-ops.test.ts tests/remote-registry-app.test.ts",
+    "test:unit": "bun test tests/parser.test.ts tests/engine.test.ts tests/mockExecutor.test.ts tests/opencodeExecutor.test.ts tests/claudeCodeExecutor.test.ts tests/remote.test.ts tests/run-telemetry.test.ts tests/supabase-functions.test.ts tests/supabase-ops.test.ts tests/remote-registry-app.test.ts",
     "test:e2e": "bun test tests/story-workflow.e2e.test.ts tests/opencode-real.e2e.test.ts",
     "test:e2e:real": "WORKFLOW_MANAGER_REAL_OPENCODE=1 bun test tests/opencode-real.e2e.test.ts",
     "test": "bun test",

--- a/spec-workflow.json
+++ b/spec-workflow.json
@@ -1,0 +1,71 @@
+{
+  "key": "spec-driven-dev",
+  "title": "Spec-Driven Development",
+  "description": "Takes a feature description, writes a spec, gets approval, then plans implementation tasks",
+  "objectives": [
+    "produce a clear structured spec",
+    "get human sign-off before implementation begins",
+    "break the approved spec into actionable tasks"
+  ],
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "feature": { "type": "string", "description": "What to build" }
+    },
+    "required": ["feature"]
+  },
+  "steps": [
+    {
+      "key": "spec",
+      "kind": "task",
+      "objective": "Write a structured spec for the feature described in the input",
+      "dependsOn": [],
+      "taskSpec": {
+        "adapterKey": "claude-code",
+        "init": {
+          "skills": ["spec-driven-development"],
+          "systemPrompts": [
+            "You are a senior engineer applying spec-driven development. Write a complete, concise spec covering: Objective, Commands, Project Structure, Code Style, Testing Strategy, and Boundaries. Output plain markdown. No preamble."
+          ]
+        },
+        "payload": {
+          "useRealAdapter": true,
+          "timeoutMs": 120000
+        }
+      }
+    },
+    {
+      "key": "spec_gate",
+      "kind": "approval",
+      "objective": "Review the spec above — approve to continue to task planning",
+      "dependsOn": ["spec"],
+      "approvalSpec": {
+        "autoApprove": false,
+        "validation": {
+          "mode": "human",
+          "required": true,
+          "autoConfirm": false
+        }
+      }
+    },
+    {
+      "key": "plan",
+      "kind": "task",
+      "objective": "Break the approved spec into a prioritized task list with acceptance criteria",
+      "dependsOn": ["spec", "spec_gate"],
+      "taskSpec": {
+        "adapterKey": "claude-code",
+        "init": {
+          "skills": ["planning-and-task-breakdown"],
+          "systemPrompts": [
+            "You are a senior engineer. Given the spec below, produce a prioritized numbered task list. For each task include: a one-line description, acceptance criteria (what done looks like), and size (S/M/L). Output plain markdown. No preamble."
+          ]
+        },
+        "payload": {
+          "useRealAdapter": true,
+          "timeoutMs": 120000
+        }
+      }
+    }
+  ]
+}

--- a/src/claudeCodeExecutor.ts
+++ b/src/claudeCodeExecutor.ts
@@ -1,0 +1,149 @@
+import { spawn } from "node:child_process";
+import type { InputEnvelope, OutputEnvelope, StepDefinition } from "./types.js";
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}
+
+export function normalizeTimeout(value: unknown, fallbackMs = 120000): number {
+  const timeout = Number(value ?? fallbackMs);
+  if (!Number.isFinite(timeout) || timeout <= 0) return fallbackMs;
+  return Math.floor(timeout);
+}
+
+function buildPrompt(step: StepDefinition, input: InputEnvelope): string {
+  const payload = asRecord(step.taskSpec?.payload);
+
+  if (typeof payload.prompt === "string" && payload.prompt.trim()) {
+    return payload.prompt;
+  }
+
+  const parts: string[] = [];
+
+  const systemPrompts = input.priming_configuration.system_prompts;
+  if (systemPrompts.length > 0) {
+    parts.push(systemPrompts.join("\n"));
+  }
+
+  const skills = input.priming_configuration.required_skills;
+  if (skills.length > 0) {
+    parts.push(`Apply the following skills: ${skills.join(", ")}`);
+  }
+
+  // Inject primitive user inputs (feature, ticket, etc.) — skip step output objects.
+  // Newlines stripped from values to reduce prompt injection surface.
+  const globalState = input.global_context.global_state;
+  const inputLines = Object.entries(globalState)
+    .filter(([, v]) => typeof v === "string" || typeof v === "number")
+    .map(([k, v]) => `${k}: ${String(v).replace(/[\n\r]/g, " ")}`);
+  if (inputLines.length > 0) {
+    parts.push(`Input:\n${inputLines.join("\n")}`);
+  }
+
+  parts.push(input.step_context.step_objective);
+
+  // Inject output from previous steps so context flows forward
+  const prev = input.step_context.previous_output;
+  for (const [key, val] of Object.entries(prev)) {
+    const rec = asRecord(val);
+    if (typeof rec.output === "string" && rec.output.trim()) {
+      parts.push(`Output from ${key}:\n${rec.output}`);
+    }
+  }
+
+  const context = input.priming_configuration.context;
+  if (context && typeof context === "object") {
+    const str = JSON.stringify(context, null, 2);
+    if (str !== "{}") parts.push(`Context:\n${str}`);
+  }
+
+  return parts.join("\n\n");
+}
+
+export function shouldUseRealClaudeCode(step: StepDefinition): boolean {
+  const payload = asRecord(step.taskSpec?.payload);
+  return payload.useRealAdapter === true;
+}
+
+export function executeClaudeCodeStep(
+  step: StepDefinition,
+  input: InputEnvelope,
+  attempt: number
+): Promise<OutputEnvelope> {
+  const startedAt = Date.now();
+  const payload = asRecord(step.taskSpec?.payload);
+  const timeoutMs = normalizeTimeout(payload.timeoutMs);
+  const prompt = buildPrompt(step, input);
+
+  const args: string[] = ["-p", prompt];
+  if (typeof payload.model === "string") {
+    args.push("--model", payload.model);
+  }
+
+  const makeResult = (
+    status: OutputEnvelope["execution_status"],
+    reason: string,
+    extra: Record<string, unknown> = {}
+  ): OutputEnvelope => ({
+    step_id: step.key,
+    execution_status: status,
+    qa_routing: { action: "PROCEED", feedback_reason: reason },
+    mutated_payload: { stepKey: step.key, attempt, adapter: "claude-code", prompt, ...extra },
+    metadata: { execution_time_ms: Date.now() - startedAt, external_intervention_required: false },
+  });
+
+  return new Promise((resolve) => {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn("claude", args);
+    } catch (err) {
+      resolve(makeResult("FAILED", (err as Error).message));
+      return;
+    }
+
+    const outChunks: string[] = [];
+    const errChunks: string[] = [];
+
+    process.stderr.write(`\n─── step: ${step.key} (claude-code) ───\n`);
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      outChunks.push(text);
+      process.stderr.write(text);
+    });
+
+    child.stderr?.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      errChunks.push(text);
+      process.stderr.write(text);
+    });
+
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+      resolve(makeResult("FAILED", `timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      if (timedOut) return;
+      resolve(makeResult("FAILED", err.message));
+    });
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (timedOut) return;
+      process.stderr.write(`\n─── end: ${step.key} ───\n`);
+      const stdout = outChunks.join("");
+      const stderr = errChunks.join("");
+      const exitStatus = code ?? 1;
+
+      if (exitStatus !== 0) {
+        resolve(makeResult("FAILED", `claude exited ${exitStatus}: ${stderr.trim()}`, { exitStatus, stdout, stderr }));
+      } else {
+        resolve(makeResult("SUCCESS", "", { exitStatus, output: stdout.trim() }));
+      }
+    });
+  });
+}

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,7 +1,9 @@
 import { randomUUID } from "node:crypto";
+import { createInterface } from "node:readline";
 import { EventLog } from "./events.js";
 import { executeMockStep } from "./mockExecutor.js";
 import { executeOpencodeStep, shouldUseRealOpencode } from "./opencodeExecutor.js";
+import { executeClaudeCodeStep, shouldUseRealClaudeCode } from "./claudeCodeExecutor.js";
 import type {
   InputEnvelope,
   OutputEnvelope,
@@ -50,17 +52,34 @@ function canConfirm(
   return { ok: false, reason: `Missing confirmation for ${step.key} (${mode})` };
 }
 
-function executeStep(step: StepDefinition, input: InputEnvelope, attempt: number): OutputEnvelope {
+function askConfirmation(stepKey: string, objective: string): Promise<boolean> {
+  if (!process.stdin.isTTY) return Promise.resolve(false);
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  return new Promise((resolve) => {
+    process.stderr.write(`\n► ${stepKey}: ${objective}\n  Approve? [y/n]: `);
+    rl.once("line", (answer) => {
+      rl.close();
+      process.stdin.resume();
+      resolve(answer.trim().toLowerCase() === "y" || answer.trim().toLowerCase() === "yes");
+    });
+  });
+}
+
+async function executeStep(step: StepDefinition, input: InputEnvelope, attempt: number): Promise<OutputEnvelope> {
   const adapterKey = step.taskSpec?.adapterKey ?? "mock";
 
   if (adapterKey === "opencode" && shouldUseRealOpencode(step)) {
     return executeOpencodeStep(step, input, attempt);
   }
 
+  if (adapterKey === "claude-code" && shouldUseRealClaudeCode(step)) {
+    return executeClaudeCodeStep(step, input, attempt);
+  }
+
   return executeMockStep(step, input, attempt);
 }
 
-export function runWorkflow(definition: WorkflowDefinition, options?: RunOptions): RunResult {
+export async function runWorkflow(definition: WorkflowDefinition, options?: RunOptions): Promise<RunResult> {
   const runId = randomUUID();
   const actor = options?.actor ?? "cli";
   const primaryObjective = options?.objective ?? definition.title;
@@ -144,7 +163,7 @@ export function runWorkflow(definition: WorkflowDefinition, options?: RunOptions
       },
     };
 
-    const output: OutputEnvelope = executeStep(step, inputEnvelope, stepRun.attempt);
+    const output: OutputEnvelope = await executeStep(step, inputEnvelope, stepRun.attempt);
     eventLog.push(
       runId,
       "step.execution_finished",
@@ -161,14 +180,17 @@ export function runWorkflow(definition: WorkflowDefinition, options?: RunOptions
       step.key
     );
 
-    const confirmation = canConfirm(step, options ?? {}, output);
-    if (!confirmation.ok) {
+    let confirmed = canConfirm(step, options ?? {}, output).ok;
+    if (!confirmed && options?.interactive && process.stdin.isTTY) {
+      confirmed = await askConfirmation(step.key, stepObjective(step, primaryObjective));
+    }
+    if (!confirmed) {
       stepRun.status = "waiting_for_approval";
       runStatus = "waiting_for_approval";
       eventLog.push(
         runId,
         "step.waiting_for_approval",
-        { reason: confirmation.reason, validation: requiresValidation(step) },
+        { reason: `confirmation required for ${step.key}`, validation: requiresValidation(step) },
         step.key
       );
       eventLog.push(runId, "run.waiting_for_approval", { reason: "confirmation required" }, step.key, actor);

--- a/src/index.ts
+++ b/src/index.ts
@@ -331,21 +331,47 @@ async function cmdRun(filePath: string): Promise<number> {
     }
 
     const objective = getFlag("--objective");
-    const inputPath = getFlag("--input");
-    const input = inputPath ? JSON.parse(fs.readFileSync(path.resolve(inputPath), "utf-8")) : {};
+    const inputRaw = getFlag("--input");
+    let input: Record<string, unknown> = {};
+    if (inputRaw) {
+      const parsed: unknown = inputRaw.trimStart().startsWith("{")
+        ? JSON.parse(inputRaw.replace(/[\n\r]/g, " "))
+        : JSON.parse(fs.readFileSync(path.resolve(inputRaw), "utf-8"));
+      if (typeof parsed !== "object" || Array.isArray(parsed) || parsed === null) {
+        console.error("--input must be a JSON object");
+        return 1;
+      }
+      input = parsed as Record<string, unknown>;
+    }
     const confirmRaw = getFlag("--confirm") ?? "";
     const confirmations = confirmRaw
       .split(",")
       .map((x) => x.trim())
       .filter(Boolean);
 
-    const result = runWorkflow(workflow, {
+    const result = await runWorkflow(workflow, {
       objective,
       input,
       confirmations,
       autoConfirmAll: hasFlag("--auto-confirm-all"),
+      interactive: process.stdin.isTTY,
     });
-    console.log(JSON.stringify(result, null, 2));
+
+    if (hasFlag("--json")) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      const icon = result.status === "succeeded" ? "✓" : result.status === "waiting_for_approval" ? "◌" : "✗";
+      process.stderr.write(`\n${icon} ${result.status} — ${workflow.title}\n\n`);
+      for (const sr of result.stepRuns) {
+        const stepIcon = sr.status === "succeeded" ? "✓" : sr.status === "waiting_for_approval" ? "◌" : "✗";
+        const adapterKey = workflow.steps.find((s) => s.key === sr.stepKey)?.taskSpec?.adapterKey ?? "approval";
+        process.stderr.write(`  ${stepIcon} ${sr.stepKey.padEnd(20)} ${adapterKey}\n`);
+      }
+      if (result.status !== "succeeded") {
+        process.stderr.write(`\nRun --json to see full output.\n`);
+      }
+      process.stderr.write("\n");
+    }
     await emitRunTelemetryBestEffort({
       definition: workflow,
       sourceFilePath: resolvedPath,

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,6 +136,7 @@ export interface RunOptions {
   actor?: string;
   confirmations?: string[];
   autoConfirmAll?: boolean;
+  interactive?: boolean;
 }
 
 export interface RunEvent {

--- a/tests/claudeCodeExecutor.test.ts
+++ b/tests/claudeCodeExecutor.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "bun:test";
+import { executeClaudeCodeStep, normalizeTimeout, shouldUseRealClaudeCode } from "../src/claudeCodeExecutor.ts";
+import type { InputEnvelope, StepDefinition } from "../src/types.ts";
+
+function baseInput(overrides: Partial<InputEnvelope["global_context"]["global_state"]> = {}): InputEnvelope {
+  return {
+    global_context: {
+      workflow_id: "run-1",
+      primary_objective: "test workflow",
+      workflow_objectives: [],
+      global_state: { ...overrides },
+    },
+    step_context: {
+      step_id: "spec",
+      step_objective: "Write a spec for the feature",
+      previous_output: {},
+      assigned_node_type: "AGENT",
+    },
+    priming_configuration: {
+      required_skills: [],
+      mcp_endpoints: [],
+      system_prompts: [],
+      adapter: "claude-code",
+    },
+  };
+}
+
+function baseStep(payloadOverrides: Record<string, unknown> = {}): StepDefinition {
+  return {
+    key: "spec",
+    kind: "task",
+    taskSpec: {
+      adapterKey: "claude-code",
+      init: { skills: [], systemPrompts: [] },
+      payload: {
+        useRealAdapter: true,
+        timeoutMs: 1, // always times out — tests prompt content without real API calls
+        ...payloadOverrides,
+      },
+    },
+  };
+}
+
+describe("shouldUseRealClaudeCode", () => {
+  it("returns false when useRealAdapter is not set", () => {
+    expect(shouldUseRealClaudeCode({ key: "s", kind: "task" })).toBe(false);
+  });
+
+  it("returns false when useRealAdapter is false", () => {
+    const step: StepDefinition = { key: "s", kind: "task", taskSpec: { payload: { useRealAdapter: false } } };
+    expect(shouldUseRealClaudeCode(step)).toBe(false);
+  });
+
+  it("returns true when useRealAdapter is true", () => {
+    const step: StepDefinition = { key: "s", kind: "task", taskSpec: { payload: { useRealAdapter: true } } };
+    expect(shouldUseRealClaudeCode(step)).toBe(true);
+  });
+});
+
+describe("executeClaudeCodeStep — output shape", () => {
+  it("always returns a complete OutputEnvelope without throwing", async () => {
+    const result = await executeClaudeCodeStep(baseStep(), baseInput(), 1);
+    expect(result.step_id).toBe("spec");
+    expect(result.execution_status).toBeOneOf(["SUCCESS", "FAILED", "QA_REJECTED", "YIELD_EXTERNAL"]);
+    expect(result.qa_routing.action).toBeDefined();
+    expect(typeof result.metadata.execution_time_ms).toBe("number");
+  });
+
+  it("sets adapter to claude-code in mutated_payload", async () => {
+    const result = await executeClaudeCodeStep(baseStep(), baseInput(), 1);
+    expect(result.mutated_payload.adapter).toBe("claude-code");
+  });
+
+  it("reflects the attempt number in mutated_payload", async () => {
+    const result = await executeClaudeCodeStep(baseStep(), baseInput(), 3);
+    expect(result.mutated_payload.attempt).toBe(3);
+  });
+
+  it("handles invalid timeout without throwing", () => {
+    expect(normalizeTimeout("not-a-number")).toBe(120000);
+    expect(normalizeTimeout(-1)).toBe(120000);
+    expect(normalizeTimeout(0)).toBe(120000);
+    expect(normalizeTimeout(5000)).toBe(5000);
+  });
+});
+
+describe("executeClaudeCodeStep — prompt construction", () => {
+  it("includes step objective in prompt", async () => {
+    const result = await executeClaudeCodeStep(baseStep(), baseInput(), 1);
+    expect(String(result.mutated_payload.prompt)).toContain("Write a spec for the feature");
+  });
+
+  it("includes system prompts", async () => {
+    const input = baseInput();
+    input.priming_configuration.system_prompts = ["You are a senior engineer."];
+    const result = await executeClaudeCodeStep(baseStep(), input, 1);
+    expect(String(result.mutated_payload.prompt)).toContain("You are a senior engineer.");
+  });
+
+  it("includes required skills", async () => {
+    const input = baseInput();
+    input.priming_configuration.required_skills = ["spec-driven-development"];
+    const result = await executeClaudeCodeStep(baseStep(), input, 1);
+    expect(String(result.mutated_payload.prompt)).toContain("spec-driven-development");
+  });
+
+  it("injects primitive global state as input variables", async () => {
+    const result = await executeClaudeCodeStep(baseStep(), baseInput({ feature: "todo CLI" }), 1);
+    expect(String(result.mutated_payload.prompt)).toContain("feature: todo CLI");
+  });
+
+  it("does not inject step output objects as input variables", async () => {
+    const input = baseInput({ spec: { stepKey: "spec", adapter: "claude-code", output: "some spec" } });
+    const result = await executeClaudeCodeStep(baseStep(), input, 1);
+    // step output objects should not appear as flat Input: lines
+    expect(String(result.mutated_payload.prompt)).not.toContain("Input:\nspec:");
+  });
+
+  it("injects previous step output into prompt", async () => {
+    const input = baseInput();
+    input.step_context.previous_output = {
+      spec: { stepKey: "spec", adapter: "claude-code", output: "## Objective\nBuild a thing." },
+    };
+    const result = await executeClaudeCodeStep(baseStep(), input, 1);
+    expect(String(result.mutated_payload.prompt)).toContain("Output from spec:");
+    expect(String(result.mutated_payload.prompt)).toContain("## Objective");
+  });
+
+  it("skips previous steps that have no string output field", async () => {
+    const input = baseInput();
+    input.step_context.previous_output = {
+      spec_gate: { stepKey: "spec_gate", adapter: "mock", mockResult: "success" },
+    };
+    const result = await executeClaudeCodeStep(baseStep(), input, 1);
+    expect(String(result.mutated_payload.prompt)).not.toContain("Output from spec_gate:");
+  });
+
+  it("uses explicit payload.prompt override instead of building", async () => {
+    const step = baseStep({ prompt: "Do exactly this thing." });
+    const result = await executeClaudeCodeStep(step, baseInput(), 1);
+    expect(String(result.mutated_payload.prompt)).toBe("Do exactly this thing.");
+  });
+
+  it("does not throw when payload.model is set", async () => {
+    const step = baseStep({ model: "claude-opus-4-5" });
+    const result = await executeClaudeCodeStep(step, baseInput(), 1);
+    expect(result.step_id).toBe("spec");
+  });
+});

--- a/tests/engine.test.ts
+++ b/tests/engine.test.ts
@@ -3,7 +3,7 @@ import { runWorkflow } from "../src/engine.ts";
 import type { WorkflowDefinition } from "../src/types.ts";
 
 describe("engine routing", () => {
-  it("retries current step and succeeds", () => {
+  it("retries current step and succeeds", async () => {
     let flips = 0;
     const wf: WorkflowDefinition = {
       key: "retry-wf",
@@ -27,12 +27,12 @@ describe("engine routing", () => {
       ],
     };
 
-    const result = runWorkflow(wf, { autoConfirmAll: true });
+    const result = await runWorkflow(wf, { autoConfirmAll: true });
     expect(result.status).toBe("succeeded");
     expect(result.events.some((e) => e.type === "step.retried")).toBe(true);
   });
 
-  it("rolls back previous and then succeeds", () => {
+  it("rolls back previous and then succeeds", async () => {
     let second = 0;
     const wf: WorkflowDefinition = {
       key: "rollback-wf",
@@ -64,13 +64,13 @@ describe("engine routing", () => {
       ],
     };
 
-    const result = runWorkflow(wf, { autoConfirmAll: true });
+    const result = await runWorkflow(wf, { autoConfirmAll: true });
     expect(result.status).toBe("succeeded");
     const retried = result.events.filter((e) => e.type === "step.retried");
     expect(retried.length).toBeGreaterThan(0);
   });
 
-  it("waits for confirmation when step requires human validation", () => {
+  it("waits for confirmation when step requires human validation", async () => {
     const wf: WorkflowDefinition = {
       key: "confirm-wf",
       title: "confirm-wf",
@@ -84,7 +84,7 @@ describe("engine routing", () => {
       ],
     } as WorkflowDefinition;
 
-    const result = runWorkflow(wf);
+    const result = await runWorkflow(wf);
     expect(result.status).toBe("waiting_for_approval");
     expect(result.events.some((e) => e.type === "step.waiting_for_approval")).toBe(true);
     expect(result.events.some((e) => e.type === "run.waiting_for_approval")).toBe(true);

--- a/tests/opencode-real.e2e.test.ts
+++ b/tests/opencode-real.e2e.test.ts
@@ -14,12 +14,12 @@ function ensureOpencodeAvailable(): void {
   }
 }
 
-function runRealWorkflow(workflowPath: string) {
+async function runRealWorkflow(workflowPath: string) {
   const workflow = parseWorkflowFile(path.resolve(workflowPath));
   return runWorkflow(workflow, { autoConfirmAll: true });
 }
 
-function assertRealOpencodeResult(result: ReturnType<typeof runWorkflow>): void {
+function assertRealOpencodeResult(result: Awaited<ReturnType<typeof runWorkflow>>): void {
   expect(result.status).toBe("succeeded");
   const probe = result.stepRuns.find((step) => step.stepKey === "opencode_probe");
   expect(probe?.status).toBe("succeeded");
@@ -33,19 +33,19 @@ function assertRealOpencodeResult(result: ReturnType<typeof runWorkflow>): void 
 }
 
 describe("opencode real adapter e2e", () => {
-  it("runs real opencode from JSON workflow when enabled", () => {
+  it("runs real opencode from JSON workflow when enabled", async () => {
     if (!ENABLE_REAL_OPENCODE) return;
     ensureOpencodeAvailable();
 
-    const result = runRealWorkflow("tests/fixtures/opencode-real-workflow.json");
+    const result = await runRealWorkflow("tests/fixtures/opencode-real-workflow.json");
     assertRealOpencodeResult(result);
   });
 
-  it("runs real opencode from Markdown workflow when enabled", () => {
+  it("runs real opencode from Markdown workflow when enabled", async () => {
     if (!ENABLE_REAL_OPENCODE) return;
     ensureOpencodeAvailable();
 
-    const result = runRealWorkflow("tests/fixtures/opencode-real-workflow.md");
+    const result = await runRealWorkflow("tests/fixtures/opencode-real-workflow.md");
     assertRealOpencodeResult(result);
   });
 });

--- a/tests/story-workflow.e2e.test.ts
+++ b/tests/story-workflow.e2e.test.ts
@@ -21,7 +21,7 @@ function withAdapter(workflow: WorkflowDefinition, adapterKey: "mock" | "opencod
   };
 }
 
-function runStoryWorkflow(workflowPath: string, adapterKey: "mock" | "opencode" = "mock") {
+async function runStoryWorkflow(workflowPath: string, adapterKey: "mock" | "opencode" = "mock") {
   const inputPath = path.resolve("tests/fixtures/story-input.json");
   const input = JSON.parse(fs.readFileSync(inputPath, "utf-8")) as Record<string, unknown>;
   const workflow = withAdapter(parseWorkflowFile(path.resolve(workflowPath)), adapterKey);
@@ -29,7 +29,7 @@ function runStoryWorkflow(workflowPath: string, adapterKey: "mock" | "opencode" 
   return runWorkflow(workflow, { input, autoConfirmAll: true });
 }
 
-function assertStoryResult(result: ReturnType<typeof runWorkflow>, adapterKey: "mock" | "opencode"): void {
+function assertStoryResult(result: Awaited<ReturnType<typeof runWorkflow>>, adapterKey: "mock" | "opencode"): void {
   expect(result.status).toBe("succeeded");
   expect(result.events.some((event) => event.type === "run.failed")).toBe(false);
 
@@ -56,23 +56,23 @@ function assertStoryResult(result: ReturnType<typeof runWorkflow>, adapterKey: "
 }
 
 describe("story workflow e2e", () => {
-  it("runs the story workflow from JSON", () => {
-    const result = runStoryWorkflow("tests/fixtures/story-workflow.json");
+  it("runs the story workflow from JSON", async () => {
+    const result = await runStoryWorkflow("tests/fixtures/story-workflow.json");
     assertStoryResult(result, "mock");
   });
 
-  it("runs the story workflow from Markdown", () => {
-    const result = runStoryWorkflow("tests/fixtures/story-workflow.md");
+  it("runs the story workflow from Markdown", async () => {
+    const result = await runStoryWorkflow("tests/fixtures/story-workflow.md");
     assertStoryResult(result, "mock");
   });
 
-  it("runs the JSON story workflow using opencode adapter", () => {
-    const result = runStoryWorkflow("tests/fixtures/story-workflow.json", "opencode");
+  it("runs the JSON story workflow using opencode adapter", async () => {
+    const result = await runStoryWorkflow("tests/fixtures/story-workflow.json", "opencode");
     assertStoryResult(result, "opencode");
   });
 
-  it("runs the Markdown story workflow using opencode adapter", () => {
-    const result = runStoryWorkflow("tests/fixtures/story-workflow.md", "opencode");
+  it("runs the Markdown story workflow using opencode adapter", async () => {
+    const result = await runStoryWorkflow("tests/fixtures/story-workflow.md", "opencode");
     assertStoryResult(result, "opencode");
   });
 });


### PR DESCRIPTION
## What this does

Before this PR, every adapter in the workflow engine — including `claude-code` — fell through to the mock executor. Running a workflow produced a JSON blob of `mockResult: "success"` with no agent actually doing anything. This PR wires up the first real adapter.

The `claude-code` adapter now calls `claude -p <prompt>` as an async subprocess. Output streams to stderr token-by-token as the model writes it, so you see the response live instead of waiting for a silent pause followed by a wall of JSON. The engine and all test call sites were made async to support this.

## What it looks like to run

```
workflow-manager run ./spec-workflow.json --input '{"feature": "a CLI that watches a folder and auto-commits changes"}'

─── step: spec (claude-code) ───
# Spec: Folder Watcher Auto-Commit CLI
## Objective
A TypeScript CLI tool that...
[streams in live]
─── end: spec ───

► spec_gate: Review the spec — approve to continue to task planning
  Approve? [y/n]: y

─── step: plan (claude-code) ───
## Task List
1. Scaffold project structure (S)...
[streams in live]
─── end: plan ───

✓ succeeded — Spec-Driven Development

  ✓ spec                 claude-code
  ✓ spec_gate            approval
  ✓ plan                 claude-code
```

The feature description comes from `--input` at runtime — no editing the workflow file per feature. The spec output automatically flows into the plan step's prompt context. The approval gate pauses the run and reads a real y/n from the terminal.

## Why this is a net add

A skill tells one agent how to do one thing better. A workflow enforces a sequence that a team runs the same way every time — gates you cannot skip, context that flows forward automatically, an audit trail of what happened. This PR is the first step that makes the workflow runner do real work instead of returning mock data.

The immediate limitation: skills listed in a step's `init.skills` are passed as names in the prompt (`Apply the following skills: spec-driven-development`) but the actual SKILL.md content isn't fetched or injected. That's the next piece — skill resolution — which is what turns this from "a prompted subprocess" into "a workflow runner that loads and applies skills". This PR establishes the executor pattern that skill loading will build on.

## Changes

| File | What changed |
|---|---|
| `src/claudeCodeExecutor.ts` | New. Async executor using `spawn`, prompt builder, streaming to stderr |
| `src/engine.ts` | Async throughout, interactive `askConfirmation` for human gates |
| `src/index.ts` | Human-readable summary by default, `--json` flag, inline `--input` JSON |
| `src/types.ts` | `interactive` field on `RunOptions` |
| `tests/claudeCodeExecutor.test.ts` | New. 16 tests: flag detection, normalizeTimeout, prompt construction |
| `tests/engine.test.ts` | async/await on all runWorkflow calls |
| `tests/story-workflow.e2e.test.ts` | async/await on all runWorkflow calls |
| `tests/opencode-real.e2e.test.ts` | async/await on all runWorkflow calls |
| `package.json` | New test file added to test:unit |
| `spec-workflow.json` | New. 3-step example: spec → gate → plan, runtime input via --input |

## Testing

- `bun run test:unit` — 57 tests, all pass
- Ran `spec-workflow.json` end-to-end with a real feature description, saw live streaming output, hit the approval gate interactively, confirmed the plan step received the spec output as context
- Code reviewed by automated reviewer — 2 criticals and 3 importants found and fixed before this PR (timeout race condition, readline cleanup between gates, zero timeout edge case, prompt injection surface, --input type validation)

## What's next

Skill resolution: when a step lists `init.skills: ["spec-driven-development"]`, fetch the SKILL.md content from the installed package or registry and prepend it to the prompt. That's what makes the workflow runner a first-class consumer of the skills ecosystem.