### PR TITLE
feat: skill resolution — workflows ship with their own skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,14 @@ npx @tanstack/intent@latest list
 npx @tanstack/intent@latest install
 ```
 
+Workflow skill resolution now follows a local-authoring + portable-artifact model:
+
+- authoring workflows can point to local skill files under `./skills/**/SKILL.md`
+- `workflow-manager publish` inlines skill markdown into `skills[*].content`
+- publish also writes `skills[*].contentSha256` for integrity checks
+- pulled workflows are rejected if any declared skill is missing embedded content
+- optional `skills[*].upstream` metadata can record source repo/ref/path for auditability
+
 See `skills/README.md` for the packaged skill layout, TanStack Intent integration, and release checks.
 
 The deployed registry dashboard also supports browser-based token creation, workflow publishing, and creator analytics.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build:bin:windows": "bun build ./src/index.ts --compile --target bun-windows-x64 --outfile ./dist/wfm-windows-x64.exe",
     "build:bin:all": "bun run build:bin:macos && bun run build:bin:linux && bun run build:bin:windows",
     "man": "man ./man/wfm.1",
-    "test:unit": "bun test tests/parser.test.ts tests/engine.test.ts tests/mockExecutor.test.ts tests/opencodeExecutor.test.ts tests/remote.test.ts tests/installer.test.ts tests/run-telemetry.test.ts tests/supabase-functions.test.ts tests/supabase-ops.test.ts tests/remote-registry-app.test.ts",
+    "test:unit": "bun test tests/parser.test.ts tests/engine.test.ts tests/mockExecutor.test.ts tests/opencodeExecutor.test.ts tests/claudeCodeExecutor.test.ts tests/remote.test.ts tests/installer.test.ts tests/run-telemetry.test.ts tests/supabase-functions.test.ts tests/supabase-ops.test.ts tests/remote-registry-app.test.ts",
     "test:e2e": "bun test tests/story-workflow.e2e.test.ts tests/opencode-real.e2e.test.ts",
     "test:e2e:real": "WORKFLOW_MANAGER_REAL_OPENCODE=1 bun test tests/opencode-real.e2e.test.ts",
     "test": "bun test",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build:bin:windows": "bun build ./src/index.ts --compile --target bun-windows-x64 --outfile ./dist/wfm-windows-x64.exe",
     "build:bin:all": "bun run build:bin:macos && bun run build:bin:linux && bun run build:bin:windows",
     "man": "man ./man/wfm.1",
-    "test:unit": "bun test tests/parser.test.ts tests/engine.test.ts tests/mockExecutor.test.ts tests/opencodeExecutor.test.ts tests/claudeCodeExecutor.test.ts tests/remote.test.ts tests/installer.test.ts tests/run-telemetry.test.ts tests/supabase-functions.test.ts tests/supabase-ops.test.ts tests/remote-registry-app.test.ts",
+    "test:unit": "bun test tests/parser.test.ts tests/engine.test.ts tests/mockExecutor.test.ts tests/opencodeExecutor.test.ts tests/claudeCodeExecutor.test.ts tests/skillResolver.test.ts tests/publish-bundle.test.ts tests/remote.test.ts tests/installer.test.ts tests/run-telemetry.test.ts tests/supabase-functions.test.ts tests/supabase-ops.test.ts tests/remote-registry-app.test.ts",
     "test:e2e": "bun test tests/story-workflow.e2e.test.ts tests/opencode-real.e2e.test.ts",
     "test:e2e:real": "WORKFLOW_MANAGER_REAL_OPENCODE=1 bun test tests/opencode-real.e2e.test.ts",
     "test": "bun test",

--- a/skills/spec-driven-development/SKILL.md
+++ b/skills/spec-driven-development/SKILL.md
@@ -1,0 +1,33 @@
+# Spec-Driven Development
+
+Write a structured specification before writing any code. The spec is the shared source of truth between you and the engineer - it defines what we're building, why, and how we'll know it's done.
+
+## When to apply
+
+Use spec-driven development when starting projects, handling ambiguous requirements, making architectural decisions, or tackling changes requiring 30+ minutes of work. Skip it for single-line fixes or unambiguous, self-contained changes.
+
+## Six-section spec format
+
+Every spec must cover these six sections in this order:
+
+1. **Objective** - One paragraph: what we are building, why, and the success criteria. Surface assumptions explicitly.
+2. **Commands** - The exact CLI / API surface. Flags, exit codes, examples.
+3. **Project Structure** - File layout with one-line responsibilities per file.
+4. **Code Style** - Language version, modules, error handling pattern, no-classes / no-comments rules, max function length.
+5. **Testing Strategy** - Unit vs integration, what gets mocked vs real, coverage gates, naming conventions.
+6. **Boundaries** - In scope, out of scope, and any non-negotiable constraints.
+
+## Practices
+
+- List assumptions before writing spec content. If they are wrong, the spec is wrong.
+- Reframe vague requirements as measurable success criteria.
+- Treat specs as living documents - update when decisions change.
+- Reference the spec from pull requests so the audit trail is visible.
+
+## Output rules
+
+- Plain markdown only. No preamble.
+- Every spec must contain all six sections, even if a section is "N/A".
+- Code style and testing strategy must include concrete rules, not vague aspirations.
+
+15 minutes of specification prevents hours of rework.

--- a/spec-workflow.json
+++ b/spec-workflow.json
@@ -16,7 +16,12 @@
   },
   "skills": {
     "spec-driven-development": {
-      "source": "./skills/spec-driven-development/SKILL.md"
+      "source": "./skills/spec-driven-development/SKILL.md",
+      "upstream": {
+        "repo": "github.com/navio/workflow-manager",
+        "ref": "main",
+        "path": "skills/spec-driven-development/SKILL.md"
+      }
     }
   },
   "steps": [

--- a/spec-workflow.json
+++ b/spec-workflow.json
@@ -1,0 +1,71 @@
+{
+  "key": "spec-driven-dev",
+  "title": "Spec-Driven Development",
+  "description": "Takes a feature description, writes a spec, gets approval, then plans implementation tasks",
+  "objectives": [
+    "produce a clear structured spec",
+    "get human sign-off before implementation begins",
+    "break the approved spec into actionable tasks"
+  ],
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "feature": { "type": "string", "description": "What to build" }
+    },
+    "required": ["feature"]
+  },
+  "steps": [
+    {
+      "key": "spec",
+      "kind": "task",
+      "objective": "Write a structured spec for the feature described in the input",
+      "dependsOn": [],
+      "taskSpec": {
+        "adapterKey": "claude-code",
+        "init": {
+          "skills": ["spec-driven-development"],
+          "systemPrompts": [
+            "You are a senior engineer applying spec-driven development. Write a complete, concise spec covering: Objective, Commands, Project Structure, Code Style, Testing Strategy, and Boundaries. Output plain markdown. No preamble."
+          ]
+        },
+        "payload": {
+          "useRealAdapter": true,
+          "timeoutMs": 120000
+        }
+      }
+    },
+    {
+      "key": "spec_gate",
+      "kind": "approval",
+      "objective": "Review the spec above — approve to continue to task planning",
+      "dependsOn": ["spec"],
+      "approvalSpec": {
+        "autoApprove": false,
+        "validation": {
+          "mode": "human",
+          "required": true,
+          "autoConfirm": false
+        }
+      }
+    },
+    {
+      "key": "plan",
+      "kind": "task",
+      "objective": "Break the approved spec into a prioritized task list with acceptance criteria",
+      "dependsOn": ["spec", "spec_gate"],
+      "taskSpec": {
+        "adapterKey": "claude-code",
+        "init": {
+          "skills": ["planning-and-task-breakdown"],
+          "systemPrompts": [
+            "You are a senior engineer. Given the spec below, produce a prioritized numbered task list. For each task include: a one-line description, acceptance criteria (what done looks like), and size (S/M/L). Output plain markdown. No preamble."
+          ]
+        },
+        "payload": {
+          "useRealAdapter": true,
+          "timeoutMs": 120000
+        }
+      }
+    }
+  ]
+}

--- a/spec-workflow.json
+++ b/spec-workflow.json
@@ -14,6 +14,11 @@
     },
     "required": ["feature"]
   },
+  "skills": {
+    "spec-driven-development": {
+      "source": "./skills/spec-driven-development/SKILL.md"
+    }
+  },
   "steps": [
     {
       "key": "spec",
@@ -25,7 +30,7 @@
         "init": {
           "skills": ["spec-driven-development"],
           "systemPrompts": [
-            "You are a senior engineer applying spec-driven development. Write a complete, concise spec covering: Objective, Commands, Project Structure, Code Style, Testing Strategy, and Boundaries. Output plain markdown. No preamble."
+            "You are a senior engineer applying spec-driven development. Output plain markdown. No preamble."
           ]
         },
         "payload": {
@@ -56,9 +61,9 @@
       "taskSpec": {
         "adapterKey": "claude-code",
         "init": {
-          "skills": ["planning-and-task-breakdown"],
+          "skills": ["spec-driven-development"],
           "systemPrompts": [
-            "You are a senior engineer. Given the spec below, produce a prioritized numbered task list. For each task include: a one-line description, acceptance criteria (what done looks like), and size (S/M/L). Output plain markdown. No preamble."
+            "You are a senior engineer. Given the spec below, produce a prioritized numbered task list. For each task include: a one-line description, acceptance criteria, and size (S/M/L). Output plain markdown. No preamble."
           ]
         },
         "payload": {

--- a/src/claudeCodeExecutor.ts
+++ b/src/claudeCodeExecutor.ts
@@ -1,0 +1,149 @@
+import { spawn } from "node:child_process";
+import type { InputEnvelope, OutputEnvelope, StepDefinition } from "./types.js";
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}
+
+export function normalizeTimeout(value: unknown, fallbackMs = 120000): number {
+  const timeout = Number(value ?? fallbackMs);
+  if (!Number.isFinite(timeout) || timeout <= 0) return fallbackMs;
+  return Math.floor(timeout);
+}
+
+function buildPrompt(step: StepDefinition, input: InputEnvelope): string {
+  const payload = asRecord(step.taskSpec?.payload);
+
+  if (typeof payload.prompt === "string" && payload.prompt.trim()) {
+    return payload.prompt;
+  }
+
+  const parts: string[] = [];
+
+  const systemPrompts = input.priming_configuration.system_prompts;
+  if (systemPrompts.length > 0) {
+    parts.push(systemPrompts.join("\n"));
+  }
+
+  const skills = input.priming_configuration.required_skills;
+  if (skills.length > 0) {
+    parts.push(`Apply the following skills: ${skills.join(", ")}`);
+  }
+
+  // Inject primitive user inputs (feature, ticket, etc.) — skip step output objects.
+  // Newlines stripped from values to reduce prompt injection surface.
+  const globalState = input.global_context.global_state;
+  const inputLines = Object.entries(globalState)
+    .filter(([, v]) => typeof v === "string" || typeof v === "number")
+    .map(([k, v]) => `${k}: ${String(v).replace(/[\n\r]/g, " ")}`);
+  if (inputLines.length > 0) {
+    parts.push(`Input:\n${inputLines.join("\n")}`);
+  }
+
+  parts.push(input.step_context.step_objective);
+
+  // Inject output from previous steps so context flows forward
+  const prev = input.step_context.previous_output;
+  for (const [key, val] of Object.entries(prev)) {
+    const rec = asRecord(val);
+    if (typeof rec.output === "string" && rec.output.trim()) {
+      parts.push(`Output from ${key}:\n${rec.output}`);
+    }
+  }
+
+  const context = input.priming_configuration.context;
+  if (context && typeof context === "object") {
+    const str = JSON.stringify(context, null, 2);
+    if (str !== "{}") parts.push(`Context:\n${str}`);
+  }
+
+  return parts.join("\n\n");
+}
+
+export function shouldUseRealClaudeCode(step: StepDefinition): boolean {
+  const payload = asRecord(step.taskSpec?.payload);
+  return payload.useRealAdapter === true;
+}
+
+export function executeClaudeCodeStep(
+  step: StepDefinition,
+  input: InputEnvelope,
+  attempt: number
+): Promise<OutputEnvelope> {
+  const startedAt = Date.now();
+  const payload = asRecord(step.taskSpec?.payload);
+  const timeoutMs = normalizeTimeout(payload.timeoutMs);
+  const prompt = buildPrompt(step, input);
+
+  const args: string[] = ["-p", prompt];
+  if (typeof payload.model === "string") {
+    args.push("--model", payload.model);
+  }
+
+  const makeResult = (
+    status: OutputEnvelope["execution_status"],
+    reason: string,
+    extra: Record<string, unknown> = {}
+  ): OutputEnvelope => ({
+    step_id: step.key,
+    execution_status: status,
+    qa_routing: { action: "PROCEED", feedback_reason: reason },
+    mutated_payload: { stepKey: step.key, attempt, adapter: "claude-code", prompt, ...extra },
+    metadata: { execution_time_ms: Date.now() - startedAt, external_intervention_required: false },
+  });
+
+  return new Promise((resolve) => {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn("claude", args);
+    } catch (err) {
+      resolve(makeResult("FAILED", (err as Error).message));
+      return;
+    }
+
+    const outChunks: string[] = [];
+    const errChunks: string[] = [];
+
+    process.stderr.write(`\n─── step: ${step.key} (claude-code) ───\n`);
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      outChunks.push(text);
+      process.stderr.write(text);
+    });
+
+    child.stderr?.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      errChunks.push(text);
+      process.stderr.write(text);
+    });
+
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+      resolve(makeResult("FAILED", `timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      if (timedOut) return;
+      resolve(makeResult("FAILED", err.message));
+    });
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (timedOut) return;
+      process.stderr.write(`\n─── end: ${step.key} ───\n`);
+      const stdout = outChunks.join("");
+      const stderr = errChunks.join("");
+      const exitStatus = code ?? 1;
+
+      if (exitStatus !== 0) {
+        resolve(makeResult("FAILED", `claude exited ${exitStatus}: ${stderr.trim()}`, { exitStatus, stdout, stderr }));
+      } else {
+        resolve(makeResult("SUCCESS", "", { exitStatus, output: stdout.trim() }));
+      }
+    });
+  });
+}

--- a/src/claudeCodeExecutor.ts
+++ b/src/claudeCodeExecutor.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
-import type { InputEnvelope, OutputEnvelope, StepDefinition } from "./types.js";
+import { resolveSkill } from "./skillResolver.js";
+import type { InputEnvelope, OutputEnvelope, StepDefinition, WorkflowDefinition } from "./types.js";
 
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
@@ -11,7 +12,12 @@ export function normalizeTimeout(value: unknown, fallbackMs = 120000): number {
   return Math.floor(timeout);
 }
 
-function buildPrompt(step: StepDefinition, input: InputEnvelope): string {
+function buildPrompt(
+  step: StepDefinition,
+  input: InputEnvelope,
+  workflow?: WorkflowDefinition,
+  workflowFilePath?: string
+): string {
   const payload = asRecord(step.taskSpec?.payload);
 
   if (typeof payload.prompt === "string" && payload.prompt.trim()) {
@@ -27,7 +33,19 @@ function buildPrompt(step: StepDefinition, input: InputEnvelope): string {
 
   const skills = input.priming_configuration.required_skills;
   if (skills.length > 0) {
-    parts.push(`Apply the following skills: ${skills.join(", ")}`);
+    const resolvedNames: string[] = [];
+    for (const name of skills) {
+      const resolved =
+        workflow && workflowFilePath ? resolveSkill(name, workflow, workflowFilePath) : null;
+      if (resolved) {
+        parts.push(resolved.content);
+      } else {
+        resolvedNames.push(name);
+      }
+    }
+    if (resolvedNames.length > 0) {
+      parts.push(`Apply the following skills: ${resolvedNames.join(", ")}`);
+    }
   }
 
   // Inject primitive user inputs (feature, ticket, etc.) — skip step output objects.
@@ -68,12 +86,14 @@ export function shouldUseRealClaudeCode(step: StepDefinition): boolean {
 export function executeClaudeCodeStep(
   step: StepDefinition,
   input: InputEnvelope,
-  attempt: number
+  attempt: number,
+  workflow?: WorkflowDefinition,
+  workflowFilePath?: string
 ): Promise<OutputEnvelope> {
   const startedAt = Date.now();
   const payload = asRecord(step.taskSpec?.payload);
   const timeoutMs = normalizeTimeout(payload.timeoutMs);
-  const prompt = buildPrompt(step, input);
+  const prompt = buildPrompt(step, input, workflow, workflowFilePath);
 
   const args: string[] = ["-p", prompt];
   if (typeof payload.model === "string") {

--- a/src/claudeCodeExecutor.ts
+++ b/src/claudeCodeExecutor.ts
@@ -6,6 +6,33 @@ function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
 }
 
+const previousOutputTextKeys = ["output", "storyMarkdown", "chapterMarkdown", "stdout"] as const;
+
+function previousOutputTextSections(value: unknown): string[] {
+  const record = asRecord(value);
+  const sections: string[] = [];
+
+  for (const key of previousOutputTextKeys) {
+    const text = record[key];
+    if (typeof text === "string" && text.trim()) {
+      sections.push(text);
+    }
+  }
+
+  if (sections.length > 0) {
+    return sections;
+  }
+
+  for (const [key, value] of Object.entries(record)) {
+    if (["stepKey", "attempt", "adapter", "command", "exitStatus", "mockResult"].includes(key)) continue;
+    if (typeof value === "string" && value.trim()) {
+      sections.push(`${key}: ${value}`);
+    }
+  }
+
+  return sections;
+}
+
 export function normalizeTimeout(value: unknown, fallbackMs = 120000): number {
   const timeout = Number(value ?? fallbackMs);
   if (!Number.isFinite(timeout) || timeout <= 0) return fallbackMs;
@@ -63,14 +90,16 @@ function buildPrompt(
   // Inject output from previous steps so context flows forward
   const prev = input.step_context.previous_output;
   for (const [key, val] of Object.entries(prev)) {
-    const rec = asRecord(val);
-    if (typeof rec.output === "string" && rec.output.trim()) {
-      parts.push(`Output from ${key}:\n${rec.output}`);
+    const sections = previousOutputTextSections(val);
+    if (sections.length > 0) {
+      parts.push(`Output from ${key}:\n${sections.join("\n\n")}`);
     }
   }
 
   const context = input.priming_configuration.context;
-  if (context && typeof context === "object") {
+  if (typeof context === "string" && context.trim()) {
+    parts.push(`Context:\n${context}`);
+  } else if (context && typeof context === "object") {
     const str = JSON.stringify(context, null, 2);
     if (str !== "{}") parts.push(`Context:\n${str}`);
   }
@@ -94,10 +123,16 @@ export function executeClaudeCodeStep(
   const payload = asRecord(step.taskSpec?.payload);
   const timeoutMs = normalizeTimeout(payload.timeoutMs);
   const prompt = buildPrompt(step, input, workflow, workflowFilePath);
+  const configuredModel =
+    typeof input.priming_configuration.model === "string" && input.priming_configuration.model.trim()
+      ? input.priming_configuration.model
+      : typeof payload.model === "string" && payload.model.trim()
+        ? payload.model
+        : undefined;
 
   const args: string[] = ["-p", prompt];
-  if (typeof payload.model === "string") {
-    args.push("--model", payload.model);
+  if (configuredModel) {
+    args.push("--model", configuredModel);
   }
 
   const makeResult = (
@@ -108,7 +143,7 @@ export function executeClaudeCodeStep(
     step_id: step.key,
     execution_status: status,
     qa_routing: { action: "PROCEED", feedback_reason: reason },
-    mutated_payload: { stepKey: step.key, attempt, adapter: "claude-code", prompt, ...extra },
+    mutated_payload: { stepKey: step.key, attempt, adapter: "claude-code", prompt, model: configuredModel, ...extra },
     metadata: { execution_time_ms: Date.now() - startedAt, external_intervention_required: false },
   });
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -33,6 +33,10 @@ function requiresValidation(step: StepDefinition): ValidationMode {
   return step.validation?.mode ?? "none";
 }
 
+export function canUseInteractiveConfirmation(step: StepDefinition): boolean {
+  return requiresValidation(step) === "human";
+}
+
 function canConfirm(
   step: StepDefinition,
   options: RunOptions,
@@ -188,7 +192,7 @@ export async function runWorkflow(definition: WorkflowDefinition, options?: RunO
     );
 
     let confirmed = canConfirm(step, options ?? {}, output).ok;
-    if (!confirmed && options?.interactive && process.stdin.isTTY) {
+    if (!confirmed && options?.interactive && process.stdin.isTTY && canUseInteractiveConfirmation(step)) {
       confirmed = await askConfirmation(step.key, stepObjective(step, primaryObjective));
     }
     if (!confirmed) {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -65,7 +65,13 @@ function askConfirmation(stepKey: string, objective: string): Promise<boolean> {
   });
 }
 
-async function executeStep(step: StepDefinition, input: InputEnvelope, attempt: number): Promise<OutputEnvelope> {
+async function executeStep(
+  step: StepDefinition,
+  input: InputEnvelope,
+  attempt: number,
+  workflow: WorkflowDefinition,
+  workflowFilePath: string
+): Promise<OutputEnvelope> {
   const adapterKey = step.taskSpec?.adapterKey ?? "mock";
 
   if (adapterKey === "opencode" && shouldUseRealOpencode(step)) {
@@ -73,7 +79,7 @@ async function executeStep(step: StepDefinition, input: InputEnvelope, attempt: 
   }
 
   if (adapterKey === "claude-code" && shouldUseRealClaudeCode(step)) {
-    return executeClaudeCodeStep(step, input, attempt);
+    return executeClaudeCodeStep(step, input, attempt, workflow, workflowFilePath);
   }
 
   return executeMockStep(step, input, attempt);
@@ -85,6 +91,7 @@ export async function runWorkflow(definition: WorkflowDefinition, options?: RunO
   const primaryObjective = options?.objective ?? definition.title;
   const workflowObjectives = definition.objectives ?? [];
   const globalState: Record<string, unknown> = { ...(options?.input ?? {}) };
+  const workflowFilePath = options?.workflowFilePath ?? "";
   const eventLog = new EventLog();
 
   let runStatus: WorkflowRunStatus = "queued";
@@ -163,7 +170,7 @@ export async function runWorkflow(definition: WorkflowDefinition, options?: RunO
       },
     };
 
-    const output: OutputEnvelope = await executeStep(step, inputEnvelope, stepRun.attempt);
+    const output: OutputEnvelope = await executeStep(step, inputEnvelope, stepRun.attempt, definition, workflowFilePath);
     eventLog.push(
       runId,
       "step.execution_finished",

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,7 +1,9 @@
 import { randomUUID } from "node:crypto";
+import { createInterface } from "node:readline";
 import { EventLog } from "./events.js";
 import { executeMockStep } from "./mockExecutor.js";
 import { executeOpencodeStep, shouldUseRealOpencode } from "./opencodeExecutor.js";
+import { executeClaudeCodeStep, shouldUseRealClaudeCode } from "./claudeCodeExecutor.js";
 import type {
   InputEnvelope,
   OutputEnvelope,
@@ -50,17 +52,34 @@ function canConfirm(
   return { ok: false, reason: `Missing confirmation for ${step.key} (${mode})` };
 }
 
-function executeStep(step: StepDefinition, input: InputEnvelope, attempt: number): OutputEnvelope {
+function askConfirmation(stepKey: string, objective: string): Promise<boolean> {
+  if (!process.stdin.isTTY) return Promise.resolve(false);
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  return new Promise((resolve) => {
+    process.stderr.write(`\n► ${stepKey}: ${objective}\n  Approve? [y/n]: `);
+    rl.once("line", (answer) => {
+      rl.close();
+      process.stdin.resume();
+      resolve(answer.trim().toLowerCase() === "y" || answer.trim().toLowerCase() === "yes");
+    });
+  });
+}
+
+async function executeStep(step: StepDefinition, input: InputEnvelope, attempt: number): Promise<OutputEnvelope> {
   const adapterKey = step.taskSpec?.adapterKey ?? "mock";
 
   if (adapterKey === "opencode" && shouldUseRealOpencode(step)) {
     return executeOpencodeStep(step, input, attempt);
   }
 
+  if (adapterKey === "claude-code" && shouldUseRealClaudeCode(step)) {
+    return executeClaudeCodeStep(step, input, attempt);
+  }
+
   return executeMockStep(step, input, attempt);
 }
 
-export function runWorkflow(definition: WorkflowDefinition, options?: RunOptions): RunResult {
+export async function runWorkflow(definition: WorkflowDefinition, options?: RunOptions): Promise<RunResult> {
   const runId = randomUUID();
   const actor = options?.actor ?? "cli";
   const primaryObjective = options?.objective ?? definition.title;
@@ -144,7 +163,7 @@ export function runWorkflow(definition: WorkflowDefinition, options?: RunOptions
       },
     };
 
-    const output: OutputEnvelope = executeStep(step, inputEnvelope, stepRun.attempt);
+    const output: OutputEnvelope = await executeStep(step, inputEnvelope, stepRun.attempt);
     eventLog.push(
       runId,
       "step.execution_finished",
@@ -161,14 +180,17 @@ export function runWorkflow(definition: WorkflowDefinition, options?: RunOptions
       step.key
     );
 
-    const confirmation = canConfirm(step, options ?? {}, output);
-    if (!confirmation.ok) {
+    let confirmed = canConfirm(step, options ?? {}, output).ok;
+    if (!confirmed && options?.interactive && process.stdin.isTTY) {
+      confirmed = await askConfirmation(step.key, stepObjective(step, primaryObjective));
+    }
+    if (!confirmed) {
       stepRun.status = "waiting_for_approval";
       runStatus = "waiting_for_approval";
       eventLog.push(
         runId,
         "step.waiting_for_approval",
-        { reason: confirmation.reason, validation: requiresValidation(step) },
+        { reason: `confirmation required for ${step.key}`, validation: requiresValidation(step) },
         step.key
       );
       eventLog.push(runId, "run.waiting_for_approval", { reason: "confirmation required" }, step.key, actor);

--- a/src/index.ts
+++ b/src/index.ts
@@ -355,6 +355,7 @@ async function cmdRun(filePath: string): Promise<number> {
       confirmations,
       autoConfirmAll: hasFlag("--auto-confirm-all"),
       interactive: process.stdin.isTTY,
+      workflowFilePath: resolvedPath,
     });
 
     if (hasFlag("--json")) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -331,21 +331,47 @@ async function cmdRun(filePath: string): Promise<number> {
     }
 
     const objective = getFlag("--objective");
-    const inputPath = getFlag("--input");
-    const input = inputPath ? JSON.parse(fs.readFileSync(path.resolve(inputPath), "utf-8")) : {};
+    const inputRaw = getFlag("--input");
+    let input: Record<string, unknown> = {};
+    if (inputRaw) {
+      const parsed: unknown = inputRaw.trimStart().startsWith("{")
+        ? JSON.parse(inputRaw.replace(/[\n\r]/g, " "))
+        : JSON.parse(fs.readFileSync(path.resolve(inputRaw), "utf-8"));
+      if (typeof parsed !== "object" || Array.isArray(parsed) || parsed === null) {
+        console.error("--input must be a JSON object");
+        return 1;
+      }
+      input = parsed as Record<string, unknown>;
+    }
     const confirmRaw = getFlag("--confirm") ?? "";
     const confirmations = confirmRaw
       .split(",")
       .map((x) => x.trim())
       .filter(Boolean);
 
-    const result = runWorkflow(workflow, {
+    const result = await runWorkflow(workflow, {
       objective,
       input,
       confirmations,
       autoConfirmAll: hasFlag("--auto-confirm-all"),
+      interactive: process.stdin.isTTY,
     });
-    console.log(JSON.stringify(result, null, 2));
+
+    if (hasFlag("--json")) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      const icon = result.status === "succeeded" ? "✓" : result.status === "waiting_for_approval" ? "◌" : "✗";
+      process.stderr.write(`\n${icon} ${result.status} — ${workflow.title}\n\n`);
+      for (const sr of result.stepRuns) {
+        const stepIcon = sr.status === "succeeded" ? "✓" : sr.status === "waiting_for_approval" ? "◌" : "✗";
+        const adapterKey = workflow.steps.find((s) => s.key === sr.stepKey)?.taskSpec?.adapterKey ?? "approval";
+        process.stderr.write(`  ${stepIcon} ${sr.stepKey.padEnd(20)} ${adapterKey}\n`);
+      }
+      if (result.status !== "succeeded") {
+        process.stderr.write(`\nRun --json to see full output.\n`);
+      }
+      process.stderr.write("\n");
+    }
     await emitRunTelemetryBestEffort({
       definition: workflow,
       sourceFilePath: resolvedPath,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -18,6 +18,7 @@ function normalizeWorkflow(data: Partial<WorkflowDefinition>, source: string): W
     inputSchema: data.inputSchema ?? {},
     outputSchema: data.outputSchema ?? {},
     defaultRetryPolicy: data.defaultRetryPolicy ?? { maxAttempts: 1 },
+    skills: data.skills,
     steps: data.steps.map((s) => ({
       ...s,
       dependsOn: s.dependsOn ?? [],

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,9 +1,63 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import matter from "gray-matter";
-import type { AdapterKey, WorkflowDefinition } from "./types.js";
+import type { AdapterKey, SkillEntry, WorkflowDefinition } from "./types.js";
 
 const SUPPORTED_ADAPTERS: AdapterKey[] = ["mock", "opencode", "codex", "claude-code"];
+const SKILL_NAME_PATTERN = /^[a-zA-Z0-9_.-]+$/;
+
+function hashContentSha256(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function isSafeSkillName(name: string): boolean {
+  return !!name && SKILL_NAME_PATTERN.test(name);
+}
+
+function isAllowedLocalSkillSourcePath(source: string): boolean {
+  if (!source || path.isAbsolute(source) || source.includes("\\") || source.includes("..")) return false;
+  const normalized = path.posix.normalize(source);
+  const withoutDot = normalized.startsWith("./") ? normalized.slice(2) : normalized;
+  if (!withoutDot.startsWith("skills/")) return false;
+  return withoutDot.endsWith("/SKILL.md");
+}
+
+function validateSkillEntry(name: string, entry: SkillEntry, errors: string[]): void {
+  if (!isSafeSkillName(name)) {
+    errors.push(`Invalid skill name: ${name}`);
+  }
+
+  if (!entry.content?.trim() && !entry.source?.trim()) {
+    errors.push(`Skill "${name}" must define content or source`);
+  }
+
+  if (entry.source && !isAllowedLocalSkillSourcePath(entry.source)) {
+    errors.push(`Skill "${name}" source must be under ./skills/**/SKILL.md`);
+  }
+
+  if (entry.contentSha256) {
+    if (!/^[a-f0-9]{64}$/.test(entry.contentSha256)) {
+      errors.push(`Skill "${name}" contentSha256 must be a 64-char lowercase hex SHA-256`);
+    } else if (!entry.content?.trim()) {
+      errors.push(`Skill "${name}" defines contentSha256 but has no content`);
+    } else if (hashContentSha256(entry.content) !== entry.contentSha256) {
+      errors.push(`Skill "${name}" contentSha256 does not match content`);
+    }
+  }
+
+  if (entry.upstream) {
+    if (entry.upstream.repo !== undefined && (!entry.upstream.repo || typeof entry.upstream.repo !== "string")) {
+      errors.push(`Skill "${name}" upstream.repo must be a non-empty string when present`);
+    }
+    if (entry.upstream.ref !== undefined && (!entry.upstream.ref || typeof entry.upstream.ref !== "string")) {
+      errors.push(`Skill "${name}" upstream.ref must be a non-empty string when present`);
+    }
+    if (entry.upstream.path !== undefined && (!entry.upstream.path || typeof entry.upstream.path !== "string")) {
+      errors.push(`Skill "${name}" upstream.path must be a non-empty string when present`);
+    }
+  }
+}
 
 function normalizeWorkflow(data: Partial<WorkflowDefinition>, source: string): WorkflowDefinition {
   if (!data.key || !data.title || !Array.isArray(data.steps)) {
@@ -81,6 +135,10 @@ export function validateWorkflow(def: WorkflowDefinition): string[] {
   if (!Array.isArray(def.steps) || def.steps.length === 0) {
     errors.push("Workflow must define at least one step");
     return errors;
+  }
+
+  for (const [name, entry] of Object.entries(def.skills ?? {})) {
+    validateSkillEntry(name, entry, errors);
   }
 
   for (const step of def.steps) {

--- a/src/remote/commands.ts
+++ b/src/remote/commands.ts
@@ -39,6 +39,31 @@ function sourceFormatFromPath(filePath: string): "markdown" | "json" {
   return path.extname(filePath).toLowerCase() === ".json" ? "json" : "markdown";
 }
 
+export function bundleSkills(workflow: WorkflowDefinition, workflowFilePath: string): WorkflowDefinition {
+  if (!workflow.skills) return workflow;
+
+  const workflowDir = path.dirname(path.resolve(workflowFilePath));
+  const bundled: Record<string, { source?: string; content?: string }> = {};
+
+  for (const [name, entry] of Object.entries(workflow.skills)) {
+    if (entry.content && entry.content.trim()) {
+      bundled[name] = entry;
+      continue;
+    }
+    if (!entry.source) {
+      throw new Error(`Skill "${name}" has neither content nor source`);
+    }
+    const sourcePath = path.resolve(workflowDir, entry.source);
+    if (!fs.existsSync(sourcePath)) {
+      throw new Error(`Skill "${name}" source file not found: ${sourcePath}`);
+    }
+    const content = fs.readFileSync(sourcePath, "utf-8");
+    bundled[name] = { source: entry.source, content };
+  }
+
+  return { ...workflow, skills: bundled };
+}
+
 function normalizeTags(raw?: string): string[] {
   if (!raw) {
     return [];
@@ -114,7 +139,6 @@ export async function cmdSearch(args: string[]): Promise<number> {
 export async function cmdPublish(filePath: string, args: string[]): Promise<number> {
   try {
     const resolvedPath = path.resolve(filePath);
-    const rawSource = fs.readFileSync(resolvedPath, "utf-8");
     const workflow = parseWorkflowFile(resolvedPath);
     const errors = validateWorkflow(workflow);
     if (errors.length > 0) {
@@ -130,6 +154,8 @@ export async function cmdPublish(filePath: string, args: string[]): Promise<numb
     const publishedState = hasFlag(args, "--draft") ? "draft" : "published";
     const tags = normalizeTags(getFlag(args, "--tag"));
     const changelog = getFlag(args, "--changelog")?.trim() || null;
+    const bundled = bundleSkills(workflow, resolvedPath);
+    const bundledRawSource = JSON.stringify(bundled, null, 2);
 
     const result = await publishRemoteWorkflow({
       slug,
@@ -138,8 +164,8 @@ export async function cmdPublish(filePath: string, args: string[]): Promise<numb
       visibility,
       versionLabel,
       sourceFormat: sourceFormatFromPath(resolvedPath),
-      rawSource,
-      definition: workflow,
+      rawSource: bundledRawSource,
+      definition: bundled,
       tags,
       changelog,
       publishedState,

--- a/src/remote/commands.ts
+++ b/src/remote/commands.ts
@@ -178,6 +178,7 @@ export async function cmdSearch(args: string[]): Promise<number> {
 export async function cmdPublish(filePath: string, args: string[]): Promise<number> {
   try {
     const resolvedPath = path.resolve(filePath);
+    const rawSource = fs.readFileSync(resolvedPath, "utf-8");
     const workflow = parseWorkflowFile(resolvedPath);
     const errors = validateWorkflow(workflow);
     if (errors.length > 0) {
@@ -194,7 +195,9 @@ export async function cmdPublish(filePath: string, args: string[]): Promise<numb
     const tags = normalizeTags(getFlag(args, "--tag"));
     const changelog = getFlag(args, "--changelog")?.trim() || null;
     const bundled = bundleSkills(workflow, resolvedPath);
-    const bundledRawSource = JSON.stringify(bundled, null, 2);
+    const hasSkills = Object.keys(bundled.skills ?? {}).length > 0;
+    const sourceFormat = hasSkills ? "json" : sourceFormatFromPath(resolvedPath);
+    const publishSource = hasSkills ? JSON.stringify(bundled, null, 2) : rawSource;
 
     const result = await publishRemoteWorkflow({
       slug,
@@ -202,8 +205,8 @@ export async function cmdPublish(filePath: string, args: string[]): Promise<numb
       description,
       visibility,
       versionLabel,
-      sourceFormat: sourceFormatFromPath(resolvedPath),
-      rawSource: bundledRawSource,
+      sourceFormat,
+      rawSource: publishSource,
       definition: bundled,
       tags,
       changelog,

--- a/src/remote/commands.ts
+++ b/src/remote/commands.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { parseWorkflowFile, validateWorkflow } from "../parser.js";
@@ -39,26 +40,64 @@ function sourceFormatFromPath(filePath: string): "markdown" | "json" {
   return path.extname(filePath).toLowerCase() === ".json" ? "json" : "markdown";
 }
 
+function hashContentSha256(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function isAllowedLocalSkillSourcePath(source: string): boolean {
+  if (!source || path.isAbsolute(source) || source.includes("\\") || source.includes("..")) return false;
+  const normalized = path.posix.normalize(source);
+  const withoutDot = normalized.startsWith("./") ? normalized.slice(2) : normalized;
+  if (!withoutDot.startsWith("skills/")) return false;
+  return withoutDot.endsWith("/SKILL.md");
+}
+
+function resolveAllowedLocalSkillSourcePath(workflowDir: string, source: string): string {
+  if (!isAllowedLocalSkillSourcePath(source)) {
+    throw new Error(`Skill source must be under ./skills/**/SKILL.md: ${source}`);
+  }
+
+  const sourcePath = path.resolve(workflowDir, source);
+  const allowedRoot = path.resolve(workflowDir, "skills");
+  if (!sourcePath.startsWith(`${allowedRoot}${path.sep}`)) {
+    throw new Error(`Skill source escapes ./skills directory: ${source}`);
+  }
+  if (path.basename(sourcePath) !== "SKILL.md") {
+    throw new Error(`Skill source must point to SKILL.md: ${source}`);
+  }
+  return sourcePath;
+}
+
 export function bundleSkills(workflow: WorkflowDefinition, workflowFilePath: string): WorkflowDefinition {
   if (!workflow.skills) return workflow;
 
   const workflowDir = path.dirname(path.resolve(workflowFilePath));
-  const bundled: Record<string, { source?: string; content?: string }> = {};
+  const bundled: NonNullable<WorkflowDefinition["skills"]> = {};
 
   for (const [name, entry] of Object.entries(workflow.skills)) {
     if (entry.content && entry.content.trim()) {
-      bundled[name] = entry;
+      const content = entry.content;
+      bundled[name] = {
+        ...entry,
+        content,
+        contentSha256: hashContentSha256(content),
+      };
       continue;
     }
     if (!entry.source) {
       throw new Error(`Skill "${name}" has neither content nor source`);
     }
-    const sourcePath = path.resolve(workflowDir, entry.source);
+    const sourcePath = resolveAllowedLocalSkillSourcePath(workflowDir, entry.source);
     if (!fs.existsSync(sourcePath)) {
       throw new Error(`Skill "${name}" source file not found: ${sourcePath}`);
     }
     const content = fs.readFileSync(sourcePath, "utf-8");
-    bundled[name] = { source: entry.source, content };
+    bundled[name] = {
+      source: entry.source,
+      upstream: entry.upstream,
+      content,
+      contentSha256: hashContentSha256(content),
+    };
   }
 
   return { ...workflow, skills: bundled };
@@ -190,10 +229,19 @@ export async function cmdPull(reference: string, args: string[]): Promise<number
 
     fs.writeFileSync(outputPath, pulled.rawSource, "utf-8");
 
-    const validationErrors = validateWorkflow(parseWorkflowFile(outputPath));
+    const parsed = parseWorkflowFile(outputPath);
+    const validationErrors = validateWorkflow(parsed);
     if (validationErrors.length > 0) {
       fs.rmSync(outputPath);
       console.error(`Pulled workflow failed local validation: ${validationErrors.join("; ")}`);
+      return 1;
+    }
+    const missingEmbeddedSkills = Object.entries(parsed.skills ?? {})
+      .filter(([, entry]) => !entry.content?.trim())
+      .map(([name]) => name);
+    if (missingEmbeddedSkills.length > 0) {
+      fs.rmSync(outputPath);
+      console.error(`Pulled workflow is missing embedded content for skills: ${missingEmbeddedSkills.join(", ")}`);
       return 1;
     }
 

--- a/src/skillResolver.ts
+++ b/src/skillResolver.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import type { WorkflowDefinition } from "./types.js";
 
 export interface ResolvedSkill {
@@ -5,14 +7,34 @@ export interface ResolvedSkill {
   origin: string;
 }
 
+function readFileSafe(filePath: string): string | null {
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    return fs.readFileSync(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
 export function resolveSkill(
   name: string,
   workflow: WorkflowDefinition,
   workflowFilePath: string
 ): ResolvedSkill | null {
-  const embedded = workflow.skills?.[name]?.content;
-  if (typeof embedded === "string" && embedded.trim()) {
-    return { content: embedded, origin: "embedded" };
+  const entry = workflow.skills?.[name];
+
+  if (entry?.content && entry.content.trim()) {
+    return { content: entry.content, origin: "embedded" };
   }
+
+  if (entry?.source) {
+    const workflowDir = path.dirname(path.resolve(workflowFilePath));
+    const sourcePath = path.resolve(workflowDir, entry.source);
+    const content = readFileSafe(sourcePath);
+    if (content && content.trim()) {
+      return { content, origin: "source" };
+    }
+  }
+
   return null;
 }

--- a/src/skillResolver.ts
+++ b/src/skillResolver.ts
@@ -22,6 +22,23 @@ function isSafeSkillName(name: string): boolean {
   return /^[a-zA-Z0-9_.-]+$/.test(name);
 }
 
+function isAllowedLocalSkillSourcePath(source: string): boolean {
+  if (!source || path.isAbsolute(source) || source.includes("\\") || source.includes("..")) return false;
+  const normalized = path.posix.normalize(source);
+  const withoutDot = normalized.startsWith("./") ? normalized.slice(2) : normalized;
+  if (!withoutDot.startsWith("skills/")) return false;
+  return withoutDot.endsWith("/SKILL.md");
+}
+
+function resolveAllowedLocalSkillSourcePath(workflowDir: string, source: string): string | null {
+  if (!isAllowedLocalSkillSourcePath(source)) return null;
+  const sourcePath = path.resolve(workflowDir, source);
+  const allowedRoot = path.resolve(workflowDir, "skills");
+  if (!sourcePath.startsWith(`${allowedRoot}${path.sep}`)) return null;
+  if (path.basename(sourcePath) !== "SKILL.md") return null;
+  return sourcePath;
+}
+
 function tryRead(...candidates: string[]): string | null {
   for (const candidate of candidates) {
     const content = readFileSafe(candidate);
@@ -43,9 +60,11 @@ export function resolveSkill(
 
   if (entry?.source) {
     const workflowDir = path.dirname(path.resolve(workflowFilePath));
-    const sourcePath = path.resolve(workflowDir, entry.source);
+    const sourcePath = resolveAllowedLocalSkillSourcePath(workflowDir, entry.source);
+    if (!sourcePath) return null;
     const content = readFileSafe(sourcePath);
     if (content && content.trim()) return { content, origin: "source" };
+    return null;
   }
 
   if (!isSafeSkillName(name)) return null;

--- a/src/skillResolver.ts
+++ b/src/skillResolver.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import type { WorkflowDefinition } from "./types.js";
 
@@ -16,6 +17,19 @@ function readFileSafe(filePath: string): string | null {
   }
 }
 
+function isSafeSkillName(name: string): boolean {
+  if (!name || name.includes("..") || name.includes("/") || name.includes("\\")) return false;
+  return /^[a-zA-Z0-9_.-]+$/.test(name);
+}
+
+function tryRead(...candidates: string[]): string | null {
+  for (const candidate of candidates) {
+    const content = readFileSafe(candidate);
+    if (content && content.trim()) return content;
+  }
+  return null;
+}
+
 export function resolveSkill(
   name: string,
   workflow: WorkflowDefinition,
@@ -31,10 +45,24 @@ export function resolveSkill(
     const workflowDir = path.dirname(path.resolve(workflowFilePath));
     const sourcePath = path.resolve(workflowDir, entry.source);
     const content = readFileSafe(sourcePath);
-    if (content && content.trim()) {
-      return { content, origin: "source" };
-    }
+    if (content && content.trim()) return { content, origin: "source" };
   }
+
+  if (!isSafeSkillName(name)) return null;
+
+  const workflowDir = path.dirname(path.resolve(workflowFilePath));
+
+  const projectLocal = tryRead(path.join(workflowDir, "skills", name, "SKILL.md"));
+  if (projectLocal) return { content: projectLocal, origin: "project-local" };
+
+  const userGlobal = tryRead(path.join(os.homedir(), ".workflow-manager", "skills", name, "SKILL.md"));
+  if (userGlobal) return { content: userGlobal, origin: "user-global" };
+
+  const packaged = tryRead(
+    path.join(workflowDir, "node_modules", "workflow-manager", "skills", name, "SKILL.md"),
+    path.join(workflowDir, "..", "node_modules", "workflow-manager", "skills", name, "SKILL.md")
+  );
+  if (packaged) return { content: packaged, origin: "npm" };
 
   return null;
 }

--- a/src/skillResolver.ts
+++ b/src/skillResolver.ts
@@ -1,0 +1,18 @@
+import type { WorkflowDefinition } from "./types.js";
+
+export interface ResolvedSkill {
+  content: string;
+  origin: string;
+}
+
+export function resolveSkill(
+  name: string,
+  workflow: WorkflowDefinition,
+  workflowFilePath: string
+): ResolvedSkill | null {
+  const embedded = workflow.skills?.[name]?.content;
+  if (typeof embedded === "string" && embedded.trim()) {
+    return { content: embedded, origin: "embedded" };
+  }
+  return null;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,9 +65,17 @@ export interface StepDefinition {
   };
 }
 
+export interface SkillUpstream {
+  repo?: string;
+  ref?: string;
+  path?: string;
+}
+
 export interface SkillEntry {
   source?: string;
   content?: string;
+  upstream?: SkillUpstream;
+  contentSha256?: string;
 }
 
 export interface WorkflowDefinition {

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,6 +143,7 @@ export interface RunOptions {
   confirmations?: string[];
   autoConfirmAll?: boolean;
   interactive?: boolean;
+  workflowFilePath?: string;
 }
 
 export interface RunEvent {

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,11 @@ export interface StepDefinition {
   };
 }
 
+export interface SkillEntry {
+  source?: string;
+  content?: string;
+}
+
 export interface WorkflowDefinition {
   key: string;
   title: string;
@@ -73,6 +78,7 @@ export interface WorkflowDefinition {
   inputSchema?: Record<string, unknown>;
   outputSchema?: Record<string, unknown>;
   defaultRetryPolicy?: RetryPolicy;
+  skills?: Record<string, SkillEntry>;
   steps: StepDefinition[];
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,6 +136,7 @@ export interface RunOptions {
   actor?: string;
   confirmations?: string[];
   autoConfirmAll?: boolean;
+  interactive?: boolean;
 }
 
 export interface RunEvent {

--- a/tests/claudeCodeExecutor.test.ts
+++ b/tests/claudeCodeExecutor.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "bun:test";
+import { executeClaudeCodeStep, normalizeTimeout, shouldUseRealClaudeCode } from "../src/claudeCodeExecutor.ts";
+import type { InputEnvelope, StepDefinition } from "../src/types.ts";
+
+function baseInput(overrides: Partial<InputEnvelope["global_context"]["global_state"]> = {}): InputEnvelope {
+  return {
+    global_context: {
+      workflow_id: "run-1",
+      primary_objective: "test workflow",
+      workflow_objectives: [],
+      global_state: { ...overrides },
+    },
+    step_context: {
+      step_id: "spec",
+      step_objective: "Write a spec for the feature",
+      previous_output: {},
+      assigned_node_type: "AGENT",
+    },
+    priming_configuration: {
+      required_skills: [],
+      mcp_endpoints: [],
+      system_prompts: [],
+      adapter: "claude-code",
+    },
+  };
+}
+
+function baseStep(payloadOverrides: Record<string, unknown> = {}): StepDefinition {
+  return {
+    key: "spec",
+    kind: "task",
+    taskSpec: {
+      adapterKey: "claude-code",
+      init: { skills: [], systemPrompts: [] },
+      payload: {
+        useRealAdapter: true,
+        timeoutMs: 1, // always times out — tests prompt content without real API calls
+        ...payloadOverrides,
+      },
+    },
+  };
+}
+
+describe("shouldUseRealClaudeCode", () => {
+  it("returns false when useRealAdapter is not set", () => {
+    expect(shouldUseRealClaudeCode({ key: "s", kind: "task" })).toBe(false);
+  });
+
+  it("returns false when useRealAdapter is false", () => {
+    const step: StepDefinition = { key: "s", kind: "task", taskSpec: { payload: { useRealAdapter: false } } };
+    expect(shouldUseRealClaudeCode(step)).toBe(false);
+  });
+
+  it("returns true when useRealAdapter is true", () => {
+    const step: StepDefinition = { key: "s", kind: "task", taskSpec: { payload: { useRealAdapter: true } } };
+    expect(shouldUseRealClaudeCode(step)).toBe(true);
+  });
+});
+
+describe("executeClaudeCodeStep — output shape", () => {
+  it("always returns a complete OutputEnvelope without throwing", async () => {
+    const result = await executeClaudeCodeStep(baseStep(), baseInput(), 1);
+    expect(result.step_id).toBe("spec");
+    expect(result.execution_status).toBeOneOf(["SUCCESS", "FAILED", "QA_REJECTED", "YIELD_EXTERNAL"]);
+    expect(result.qa_routing.action).toBeDefined();
+    expect(typeof result.metadata.execution_time_ms).toBe("number");
+  });
+
+  it("sets adapter to claude-code in mutated_payload", async () => {
+    const result = await executeClaudeCodeStep(baseStep(), baseInput(), 1);
+    expect(result.mutated_payload.adapter).toBe("claude-code");
+  });
+
+  it("reflects the attempt number in mutated_payload", async () => {
+    const result = await executeClaudeCodeStep(baseStep(), baseInput(), 3);
+    expect(result.mutated_payload.attempt).toBe(3);
+  });
+
+  it("handles invalid timeout without throwing", () => {
+    expect(normalizeTimeout("not-a-number")).toBe(120000);
+    expect(normalizeTimeout(-1)).toBe(120000);
+    expect(normalizeTimeout(0)).toBe(120000);
+    expect(normalizeTimeout(5000)).toBe(5000);
+  });
+});
+
+describe("executeClaudeCodeStep — prompt construction", () => {
+  it("includes step objective in prompt", async () => {
+    const result = await executeClaudeCodeStep(baseStep(), baseInput(), 1);
+    expect(String(result.mutated_payload.prompt)).toContain("Write a spec for the feature");
+  });
+
+  it("includes system prompts", async () => {
+    const input = baseInput();
+    input.priming_configuration.system_prompts = ["You are a senior engineer."];
+    const result = await executeClaudeCodeStep(baseStep(), input, 1);
+    expect(String(result.mutated_payload.prompt)).toContain("You are a senior engineer.");
+  });
+
+  it("includes required skills", async () => {
+    const input = baseInput();
+    input.priming_configuration.required_skills = ["spec-driven-development"];
+    const result = await executeClaudeCodeStep(baseStep(), input, 1);
+    expect(String(result.mutated_payload.prompt)).toContain("spec-driven-development");
+  });
+
+  it("injects primitive global state as input variables", async () => {
+    const result = await executeClaudeCodeStep(baseStep(), baseInput({ feature: "todo CLI" }), 1);
+    expect(String(result.mutated_payload.prompt)).toContain("feature: todo CLI");
+  });
+
+  it("does not inject step output objects as input variables", async () => {
+    const input = baseInput({ spec: { stepKey: "spec", adapter: "claude-code", output: "some spec" } });
+    const result = await executeClaudeCodeStep(baseStep(), input, 1);
+    // step output objects should not appear as flat Input: lines
+    expect(String(result.mutated_payload.prompt)).not.toContain("Input:\nspec:");
+  });
+
+  it("injects previous step output into prompt", async () => {
+    const input = baseInput();
+    input.step_context.previous_output = {
+      spec: { stepKey: "spec", adapter: "claude-code", output: "## Objective\nBuild a thing." },
+    };
+    const result = await executeClaudeCodeStep(baseStep(), input, 1);
+    expect(String(result.mutated_payload.prompt)).toContain("Output from spec:");
+    expect(String(result.mutated_payload.prompt)).toContain("## Objective");
+  });
+
+  it("skips previous steps that have no string output field", async () => {
+    const input = baseInput();
+    input.step_context.previous_output = {
+      spec_gate: { stepKey: "spec_gate", adapter: "mock", mockResult: "success" },
+    };
+    const result = await executeClaudeCodeStep(baseStep(), input, 1);
+    expect(String(result.mutated_payload.prompt)).not.toContain("Output from spec_gate:");
+  });
+
+  it("uses explicit payload.prompt override instead of building", async () => {
+    const step = baseStep({ prompt: "Do exactly this thing." });
+    const result = await executeClaudeCodeStep(step, baseInput(), 1);
+    expect(String(result.mutated_payload.prompt)).toBe("Do exactly this thing.");
+  });
+
+  it("does not throw when payload.model is set", async () => {
+    const step = baseStep({ model: "claude-opus-4-5" });
+    const result = await executeClaudeCodeStep(step, baseInput(), 1);
+    expect(result.step_id).toBe("spec");
+  });
+});

--- a/tests/claudeCodeExecutor.test.ts
+++ b/tests/claudeCodeExecutor.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { executeClaudeCodeStep, normalizeTimeout, shouldUseRealClaudeCode } from "../src/claudeCodeExecutor.ts";
-import type { InputEnvelope, StepDefinition } from "../src/types.ts";
+import type { InputEnvelope, StepDefinition, WorkflowDefinition } from "../src/types.ts";
 
 function baseInput(overrides: Partial<InputEnvelope["global_context"]["global_state"]> = {}): InputEnvelope {
   return {
@@ -145,5 +145,33 @@ describe("executeClaudeCodeStep — prompt construction", () => {
     const step = baseStep({ model: "claude-opus-4-5" });
     const result = await executeClaudeCodeStep(step, baseInput(), 1);
     expect(result.step_id).toBe("spec");
+  });
+});
+
+describe("executeClaudeCodeStep — skill resolution", () => {
+  it("injects embedded skill content into the prompt", async () => {
+    const input = baseInput();
+    input.priming_configuration.required_skills = ["spec-driven-development"];
+    const step = baseStep();
+    const workflow: WorkflowDefinition = {
+      key: "wf",
+      title: "wf",
+      steps: [],
+      skills: {
+        "spec-driven-development": { content: "# Spec-Driven\n\nApply this method." },
+      },
+    };
+    const result = await executeClaudeCodeStep(step, input, 1, workflow, "/tmp/wf.json");
+    expect(String(result.mutated_payload.prompt)).toContain("# Spec-Driven");
+    expect(String(result.mutated_payload.prompt)).toContain("Apply this method.");
+  });
+
+  it("falls back to plain skill name line when skill is not resolved", async () => {
+    const input = baseInput();
+    input.priming_configuration.required_skills = ["unknown-skill"];
+    const step = baseStep();
+    const workflow: WorkflowDefinition = { key: "wf", title: "wf", steps: [], skills: {} };
+    const result = await executeClaudeCodeStep(step, input, 1, workflow, "/tmp/nonexistent/wf.json");
+    expect(String(result.mutated_payload.prompt)).toContain("Apply the following skills: unknown-skill");
   });
 });

--- a/tests/claudeCodeExecutor.test.ts
+++ b/tests/claudeCodeExecutor.test.ts
@@ -135,6 +135,17 @@ describe("executeClaudeCodeStep — prompt construction", () => {
     expect(String(result.mutated_payload.prompt)).not.toContain("Output from spec_gate:");
   });
 
+  it("injects text fields from non-claude previous step outputs", async () => {
+    const input = baseInput();
+    input.step_context.previous_output = {
+      render_story: { stepKey: "render_story", adapter: "mock", storyMarkdown: "# Story\n\nA bunny wins." },
+      smoke_test: { stepKey: "smoke_test", adapter: "opencode", stdout: "All checks passed" },
+    };
+    const result = await executeClaudeCodeStep(baseStep(), input, 1);
+    expect(String(result.mutated_payload.prompt)).toContain("# Story");
+    expect(String(result.mutated_payload.prompt)).toContain("All checks passed");
+  });
+
   it("uses explicit payload.prompt override instead of building", async () => {
     const step = baseStep({ prompt: "Do exactly this thing." });
     const result = await executeClaudeCodeStep(step, baseInput(), 1);
@@ -145,6 +156,22 @@ describe("executeClaudeCodeStep — prompt construction", () => {
     const step = baseStep({ model: "claude-opus-4-5" });
     const result = await executeClaudeCodeStep(step, baseInput(), 1);
     expect(result.step_id).toBe("spec");
+    expect(result.mutated_payload.model).toBe("claude-opus-4-5");
+  });
+
+  it("prefers init.model passed through priming_configuration", async () => {
+    const input = baseInput();
+    input.priming_configuration.model = "claude-sonnet-4";
+    const step = baseStep({ model: "claude-opus-4-5" });
+    const result = await executeClaudeCodeStep(step, input, 1);
+    expect(result.mutated_payload.model).toBe("claude-sonnet-4");
+  });
+
+  it("includes string context", async () => {
+    const input = baseInput();
+    input.priming_configuration.context = "Repo conventions: use ESM imports.";
+    const result = await executeClaudeCodeStep(baseStep(), input, 1);
+    expect(String(result.mutated_payload.prompt)).toContain("Context:\nRepo conventions: use ESM imports.");
   });
 });
 

--- a/tests/engine.test.ts
+++ b/tests/engine.test.ts
@@ -3,7 +3,7 @@ import { runWorkflow } from "../src/engine.ts";
 import type { WorkflowDefinition } from "../src/types.ts";
 
 describe("engine routing", () => {
-  it("retries current step and succeeds", () => {
+  it("retries current step and succeeds", async () => {
     let flips = 0;
     const wf: WorkflowDefinition = {
       key: "retry-wf",
@@ -27,12 +27,12 @@ describe("engine routing", () => {
       ],
     };
 
-    const result = runWorkflow(wf, { autoConfirmAll: true });
+    const result = await runWorkflow(wf, { autoConfirmAll: true });
     expect(result.status).toBe("succeeded");
     expect(result.events.some((e) => e.type === "step.retried")).toBe(true);
   });
 
-  it("rolls back previous and then succeeds", () => {
+  it("rolls back previous and then succeeds", async () => {
     let second = 0;
     const wf: WorkflowDefinition = {
       key: "rollback-wf",
@@ -64,13 +64,13 @@ describe("engine routing", () => {
       ],
     };
 
-    const result = runWorkflow(wf, { autoConfirmAll: true });
+    const result = await runWorkflow(wf, { autoConfirmAll: true });
     expect(result.status).toBe("succeeded");
     const retried = result.events.filter((e) => e.type === "step.retried");
     expect(retried.length).toBeGreaterThan(0);
   });
 
-  it("waits for confirmation when step requires human validation", () => {
+  it("waits for confirmation when step requires human validation", async () => {
     const wf: WorkflowDefinition = {
       key: "confirm-wf",
       title: "confirm-wf",
@@ -84,7 +84,7 @@ describe("engine routing", () => {
       ],
     } as WorkflowDefinition;
 
-    const result = runWorkflow(wf);
+    const result = await runWorkflow(wf);
     expect(result.status).toBe("waiting_for_approval");
     expect(result.events.some((e) => e.type === "step.waiting_for_approval")).toBe(true);
     expect(result.events.some((e) => e.type === "run.waiting_for_approval")).toBe(true);

--- a/tests/engine.test.ts
+++ b/tests/engine.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { runWorkflow } from "../src/engine.ts";
+import { canUseInteractiveConfirmation, runWorkflow } from "../src/engine.ts";
 import type { WorkflowDefinition } from "../src/types.ts";
 
 describe("engine routing", () => {
@@ -89,5 +89,23 @@ describe("engine routing", () => {
     expect(result.events.some((e) => e.type === "step.waiting_for_approval")).toBe(true);
     expect(result.events.some((e) => e.type === "run.waiting_for_approval")).toBe(true);
     expect(result.events.some((e) => e.type === "run.cancelled")).toBe(false);
+  });
+
+  it("only allows interactive confirmation for human validation", () => {
+    expect(
+      canUseInteractiveConfirmation({
+        key: "human-step",
+        kind: "task",
+        validation: { mode: "human", required: true, autoConfirm: false },
+      })
+    ).toBe(true);
+
+    expect(
+      canUseInteractiveConfirmation({
+        key: "external-step",
+        kind: "task",
+        validation: { mode: "external", required: true, autoConfirm: false },
+      })
+    ).toBe(false);
   });
 });

--- a/tests/opencode-real.e2e.test.ts
+++ b/tests/opencode-real.e2e.test.ts
@@ -14,12 +14,12 @@ function ensureOpencodeAvailable(): void {
   }
 }
 
-function runRealWorkflow(workflowPath: string) {
+async function runRealWorkflow(workflowPath: string) {
   const workflow = parseWorkflowFile(path.resolve(workflowPath));
   return runWorkflow(workflow, { autoConfirmAll: true });
 }
 
-function assertRealOpencodeResult(result: ReturnType<typeof runWorkflow>): void {
+function assertRealOpencodeResult(result: Awaited<ReturnType<typeof runWorkflow>>): void {
   expect(result.status).toBe("succeeded");
   const probe = result.stepRuns.find((step) => step.stepKey === "opencode_probe");
   expect(probe?.status).toBe("succeeded");
@@ -33,19 +33,19 @@ function assertRealOpencodeResult(result: ReturnType<typeof runWorkflow>): void 
 }
 
 describe("opencode real adapter e2e", () => {
-  it("runs real opencode from JSON workflow when enabled", () => {
+  it("runs real opencode from JSON workflow when enabled", async () => {
     if (!ENABLE_REAL_OPENCODE) return;
     ensureOpencodeAvailable();
 
-    const result = runRealWorkflow("tests/fixtures/opencode-real-workflow.json");
+    const result = await runRealWorkflow("tests/fixtures/opencode-real-workflow.json");
     assertRealOpencodeResult(result);
   });
 
-  it("runs real opencode from Markdown workflow when enabled", () => {
+  it("runs real opencode from Markdown workflow when enabled", async () => {
     if (!ENABLE_REAL_OPENCODE) return;
     ensureOpencodeAvailable();
 
-    const result = runRealWorkflow("tests/fixtures/opencode-real-workflow.md");
+    const result = await runRealWorkflow("tests/fixtures/opencode-real-workflow.md");
     assertRealOpencodeResult(result);
   });
 });

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -152,5 +153,62 @@ describe("parser — skills field", () => {
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("parser — skills validation", () => {
+  function sha256(value: string): string {
+    return createHash("sha256").update(value).digest("hex");
+  }
+
+  it("rejects skill source paths outside ./skills/**/SKILL.md", () => {
+    const wf = {
+      key: "k",
+      title: "t",
+      skills: {
+        demo: { source: "./README.md" },
+      },
+      steps: [{ key: "s1", kind: "task", taskSpec: { adapterKey: "mock" } }],
+    } as ReturnType<typeof parseWorkflowJson>;
+    const errors = validateWorkflow(wf);
+    expect(errors).toContain('Skill "demo" source must be under ./skills/**/SKILL.md');
+  });
+
+  it("rejects mismatched contentSha256", () => {
+    const wf = {
+      key: "k",
+      title: "t",
+      skills: {
+        demo: {
+          content: "# Skill",
+          contentSha256: sha256("# different"),
+        },
+      },
+      steps: [{ key: "s1", kind: "task", taskSpec: { adapterKey: "mock" } }],
+    } as ReturnType<typeof parseWorkflowJson>;
+    const errors = validateWorkflow(wf);
+    expect(errors).toContain('Skill "demo" contentSha256 does not match content');
+  });
+
+  it("accepts matching hash and upstream metadata", () => {
+    const content = "# Skill";
+    const wf = {
+      key: "k",
+      title: "t",
+      skills: {
+        demo: {
+          source: "./skills/demo/SKILL.md",
+          content,
+          contentSha256: sha256(content),
+          upstream: {
+            repo: "github.com/acme/skills",
+            ref: "abc123",
+            path: "demo/SKILL.md",
+          },
+        },
+      },
+      steps: [{ key: "s1", kind: "task", taskSpec: { adapterKey: "mock" } }],
+    } as ReturnType<typeof parseWorkflowJson>;
+    expect(validateWorkflow(wf)).toEqual([]);
   });
 });

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -128,3 +128,29 @@ steps:
     expect(errors).toContain("Task step s1 is missing taskSpec");
   });
 });
+
+describe("parser — skills field", () => {
+  it("preserves the skills map through normalization", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "wm-parser-"));
+    try {
+      const file = path.join(tmpDir, "wf.json");
+      fs.writeFileSync(
+        file,
+        JSON.stringify({
+          key: "k",
+          title: "t",
+          skills: {
+            "my-skill": { content: "# Embedded" },
+            "ref-skill": { source: "./skills/ref/SKILL.md" },
+          },
+          steps: [{ key: "s1", kind: "task", taskSpec: { adapterKey: "mock" } }],
+        })
+      );
+      const parsed = parseWorkflowFile(file);
+      expect(parsed.skills?.["my-skill"]?.content).toBe("# Embedded");
+      expect(parsed.skills?.["ref-skill"]?.source).toBe("./skills/ref/SKILL.md");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/publish-bundle.test.ts
+++ b/tests/publish-bundle.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { bundleSkills } from "../src/remote/commands.ts";
+import type { WorkflowDefinition } from "../src/types.ts";
+
+describe("bundleSkills", () => {
+  it("inlines content from skills[name].source paths", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wm-bundle-"));
+    try {
+      const skillDir = path.join(dir, "skills", "demo");
+      fs.mkdirSync(skillDir, { recursive: true });
+      fs.writeFileSync(path.join(skillDir, "SKILL.md"), "# Demo\n\nDo the thing.");
+      const wf: WorkflowDefinition = {
+        key: "k",
+        title: "t",
+        steps: [],
+        skills: { demo: { source: "./skills/demo/SKILL.md" } },
+      };
+      const workflowFile = path.join(dir, "wf.json");
+      fs.writeFileSync(workflowFile, JSON.stringify(wf));
+
+      const bundled = bundleSkills(wf, workflowFile);
+      expect(bundled.skills?.demo?.content).toBe("# Demo\n\nDo the thing.");
+      expect(bundled.skills?.demo?.source).toBe("./skills/demo/SKILL.md");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves already-embedded content unchanged", () => {
+    const wf: WorkflowDefinition = {
+      key: "k",
+      title: "t",
+      steps: [],
+      skills: { demo: { content: "# Already embedded" } },
+    };
+    const bundled = bundleSkills(wf, "/tmp/wf.json");
+    expect(bundled.skills?.demo?.content).toBe("# Already embedded");
+  });
+
+  it("throws on missing source path", () => {
+    const wf: WorkflowDefinition = {
+      key: "k",
+      title: "t",
+      steps: [],
+      skills: { demo: { source: "./does-not-exist.md" } },
+    };
+    expect(() => bundleSkills(wf, "/tmp/nonexistent/wf.json")).toThrow();
+  });
+
+  it("returns workflow unchanged when no skills map", () => {
+    const wf: WorkflowDefinition = { key: "k", title: "t", steps: [] };
+    const bundled = bundleSkills(wf, "/tmp/wf.json");
+    expect(bundled.skills).toBeUndefined();
+  });
+});

--- a/tests/publish-bundle.test.ts
+++ b/tests/publish-bundle.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -6,6 +7,10 @@ import { bundleSkills } from "../src/remote/commands.ts";
 import type { WorkflowDefinition } from "../src/types.ts";
 
 describe("bundleSkills", () => {
+  function sha256(value: string): string {
+    return createHash("sha256").update(value).digest("hex");
+  }
+
   it("inlines content from skills[name].source paths", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wm-bundle-"));
     try {
@@ -24,6 +29,7 @@ describe("bundleSkills", () => {
       const bundled = bundleSkills(wf, workflowFile);
       expect(bundled.skills?.demo?.content).toBe("# Demo\n\nDo the thing.");
       expect(bundled.skills?.demo?.source).toBe("./skills/demo/SKILL.md");
+      expect(bundled.skills?.demo?.contentSha256).toBe(sha256("# Demo\n\nDo the thing."));
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -38,6 +44,7 @@ describe("bundleSkills", () => {
     };
     const bundled = bundleSkills(wf, "/tmp/wf.json");
     expect(bundled.skills?.demo?.content).toBe("# Already embedded");
+    expect(bundled.skills?.demo?.contentSha256).toBe(sha256("# Already embedded"));
   });
 
   it("throws on missing source path", () => {
@@ -48,6 +55,39 @@ describe("bundleSkills", () => {
       skills: { demo: { source: "./does-not-exist.md" } },
     };
     expect(() => bundleSkills(wf, "/tmp/nonexistent/wf.json")).toThrow();
+  });
+
+  it("throws on source path outside allowed local skills directory", () => {
+    const wf: WorkflowDefinition = {
+      key: "k",
+      title: "t",
+      steps: [],
+      skills: { demo: { source: "./README.md" } },
+    };
+    expect(() => bundleSkills(wf, "/tmp/wf.json")).toThrow();
+  });
+
+  it("preserves upstream metadata while adding hash", () => {
+    const wf: WorkflowDefinition = {
+      key: "k",
+      title: "t",
+      steps: [],
+      skills: {
+        demo: {
+          content: "# Already embedded",
+          upstream: {
+            repo: "github.com/acme/skills",
+            ref: "abc123",
+            path: "demo/SKILL.md",
+          },
+        },
+      },
+    };
+    const bundled = bundleSkills(wf, "/tmp/wf.json");
+    expect(bundled.skills?.demo?.upstream?.repo).toBe("github.com/acme/skills");
+    expect(bundled.skills?.demo?.upstream?.ref).toBe("abc123");
+    expect(bundled.skills?.demo?.upstream?.path).toBe("demo/SKILL.md");
+    expect(bundled.skills?.demo?.contentSha256).toBe(sha256("# Already embedded"));
   });
 
   it("returns workflow unchanged when no skills map", () => {

--- a/tests/remote.test.ts
+++ b/tests/remote.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -125,6 +126,10 @@ async function runCliCommand(args: string[], env: NodeJS.ProcessEnv, timeoutMs =
 }
 
 describe("remote CLI integration helpers", () => {
+  function sha256(value: string): string {
+    return createHash("sha256").update(value).digest("hex");
+  }
+
   it("auth login stores the token after whoami succeeds", async () => {
     await withServer((request) => {
       expect(request.pathname).toBe("/functions/v1/auth-whoami");
@@ -180,6 +185,57 @@ describe("remote CLI integration helpers", () => {
     });
   });
 
+  it("publish bundles local skill content and hash", async () => {
+    const workflowPath = path.join(configDir, "workflow-with-skills.json");
+    const skillDir = path.join(configDir, "skills", "demo");
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, "SKILL.md"), "# Demo skill", "utf-8");
+    fs.writeFileSync(
+      workflowPath,
+      JSON.stringify({
+        key: "remote-bunny",
+        title: "Remote Bunny",
+        skills: {
+          demo: {
+            source: "./skills/demo/SKILL.md",
+            upstream: {
+              repo: "github.com/acme/skills",
+              ref: "abc123",
+              path: "demo/SKILL.md",
+            },
+          },
+        },
+        steps: [
+          {
+            key: "plan",
+            kind: "task",
+            taskSpec: {
+              adapterKey: "mock",
+              init: { skills: ["demo"] },
+              payload: { mockResult: "success" },
+            },
+          },
+        ],
+      }),
+      "utf-8"
+    );
+    fs.writeFileSync(configFilePath(), JSON.stringify({ token: "publish-token" }), "utf-8");
+
+    await withServer((request) => {
+      expect(request.pathname).toBe("/functions/v1/publish-workflow");
+      const body = JSON.parse(request.body) as Record<string, unknown>;
+      const definition = body.definition as Record<string, unknown>;
+      const skills = definition.skills as Record<string, Record<string, unknown>>;
+      expect(skills.demo.content).toBe("# Demo skill");
+      expect(skills.demo.contentSha256).toBe(sha256("# Demo skill"));
+      expect((skills.demo.upstream as Record<string, string>).repo).toBe("github.com/acme/skills");
+      return Response.json({ slug: body.slug, version: body.versionLabel }, { status: 201 });
+    }, async () => {
+      const exitCode = await cmdPublish(workflowPath, []);
+      expect(exitCode).toBe(0);
+    });
+  });
+
   it("pull writes the workflow file locally and validates it", async () => {
     const outputPath = path.join(configDir, "pulled.json");
     await withServer((request) => {
@@ -220,6 +276,54 @@ describe("remote CLI integration helpers", () => {
       expect(exitCode).toBe(0);
       const pulled = JSON.parse(fs.readFileSync(outputPath, "utf-8")) as Record<string, unknown>;
       expect(pulled.key).toBe("remote-bunny");
+    });
+  });
+
+  it("pull rejects workflows that do not embed required skill content", async () => {
+    const outputPath = path.join(configDir, "pulled-missing-content.json");
+    await withServer(() => {
+      return Response.json({
+        owner: "alice",
+        slug: "remote-bunny",
+        title: "Remote Bunny",
+        description: "shared workflow",
+        visibility: "public",
+        version: "v1",
+        sourceFormat: "json",
+        rawSource: JSON.stringify({
+          key: "remote-bunny",
+          title: "Remote Bunny",
+          skills: {
+            demo: {
+              source: "./skills/demo/SKILL.md",
+            },
+          },
+          steps: [
+            {
+              key: "plan",
+              kind: "task",
+              taskSpec: {
+                adapterKey: "mock",
+                init: { skills: ["demo"] },
+                payload: { mockResult: "success" },
+              },
+            },
+          ],
+        }),
+        definition: {
+          key: "remote-bunny",
+          title: "Remote Bunny",
+          skills: { demo: { source: "./skills/demo/SKILL.md" } },
+          steps: [{ key: "plan", kind: "task", taskSpec: { adapterKey: "mock" } }],
+        },
+        changelog: null,
+        publishedState: "published",
+        createdAt: new Date().toISOString(),
+      });
+    }, async () => {
+      const exitCode = await cmdPull("alice/remote-bunny", ["--output", outputPath]);
+      expect(exitCode).toBe(1);
+      expect(fs.existsSync(outputPath)).toBe(false);
     });
   });
 

--- a/tests/remote.test.ts
+++ b/tests/remote.test.ts
@@ -236,6 +236,47 @@ describe("remote CLI integration helpers", () => {
     });
   });
 
+  it("publish stores bundled markdown workflows as json artifacts", async () => {
+    const workflowPath = path.join(configDir, "workflow-with-skills.md");
+    const skillDir = path.join(configDir, "skills", "demo");
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, "SKILL.md"), "# Demo skill", "utf-8");
+    fs.writeFileSync(
+      workflowPath,
+      `---
+key: remote-bunny
+title: Remote Bunny
+skills:
+  demo:
+    source: ./skills/demo/SKILL.md
+steps:
+  - key: plan
+    kind: task
+    taskSpec:
+      adapterKey: mock
+      init:
+        skills: [demo]
+      payload:
+        mockResult: success
+---
+`,
+      "utf-8"
+    );
+    fs.writeFileSync(configFilePath(), JSON.stringify({ token: "publish-token" }), "utf-8");
+
+    await withServer((request) => {
+      const body = JSON.parse(request.body) as Record<string, unknown>;
+      expect(body.sourceFormat).toBe("json");
+      const rawSource = JSON.parse(String(body.rawSource)) as Record<string, unknown>;
+      const skills = rawSource.skills as Record<string, Record<string, unknown>>;
+      expect(skills.demo.content).toBe("# Demo skill");
+      return Response.json({ slug: body.slug, version: body.versionLabel }, { status: 201 });
+    }, async () => {
+      const exitCode = await cmdPublish(workflowPath, []);
+      expect(exitCode).toBe(0);
+    });
+  });
+
   it("pull writes the workflow file locally and validates it", async () => {
     const outputPath = path.join(configDir, "pulled.json");
     await withServer((request) => {

--- a/tests/skillResolver.test.ts
+++ b/tests/skillResolver.test.ts
@@ -11,7 +11,9 @@ function baseWorkflow(skills: WorkflowDefinition["skills"] = {}): WorkflowDefini
 
 function withTempWorkflow(skillContent: string, fn: (workflowFile: string, skillFile: string) => void): void {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wm-skill-"));
-  const skillFile = path.join(dir, "MY_SKILL.md");
+  const skillDir = path.join(dir, "skills", "my-skill");
+  fs.mkdirSync(skillDir, { recursive: true });
+  const skillFile = path.join(skillDir, "SKILL.md");
   const workflowFile = path.join(dir, "wf.json");
   fs.writeFileSync(skillFile, skillContent);
   fs.writeFileSync(workflowFile, "{}");
@@ -43,7 +45,7 @@ describe("resolveSkill — workflow source path", () => {
   it("reads content from skills[name].source path relative to workflow file", () => {
     withTempWorkflow("# From source\n\nLoaded from path.", (workflowFile, _skillFile) => {
       const wf = baseWorkflow({
-        "my-skill": { source: "./MY_SKILL.md" },
+        "my-skill": { source: "./skills/my-skill/SKILL.md" },
       });
       const result = resolveSkill("my-skill", wf, workflowFile);
       expect(result?.content).toBe("# From source\n\nLoaded from path.");
@@ -54,7 +56,7 @@ describe("resolveSkill — workflow source path", () => {
   it("prefers embedded content over source path when both present", () => {
     withTempWorkflow("# from disk", (workflowFile, _skillFile) => {
       const wf = baseWorkflow({
-        "my-skill": { source: "./MY_SKILL.md", content: "# embedded wins" },
+        "my-skill": { source: "./skills/my-skill/SKILL.md", content: "# embedded wins" },
       });
       const result = resolveSkill("my-skill", wf, workflowFile);
       expect(result?.content).toBe("# embedded wins");
@@ -68,6 +70,16 @@ describe("resolveSkill — workflow source path", () => {
     });
     const result = resolveSkill("my-skill", wf, "/tmp/nonexistent-dir/wf.json");
     expect(result).toBeNull();
+  });
+
+  it("returns null when source path is outside allowed skills directory", () => {
+    withTempWorkflow("# from disk", (workflowFile, _skillFile) => {
+      const wf = baseWorkflow({
+        "my-skill": { source: "./README.md" },
+      });
+      const result = resolveSkill("my-skill", wf, workflowFile);
+      expect(result).toBeNull();
+    });
   });
 });
 

--- a/tests/skillResolver.test.ts
+++ b/tests/skillResolver.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import { resolveSkill } from "../src/skillResolver.ts";
+import type { WorkflowDefinition } from "../src/types.ts";
+
+function baseWorkflow(skills: WorkflowDefinition["skills"] = {}): WorkflowDefinition {
+  return { key: "wf", title: "wf", steps: [], skills };
+}
+
+describe("resolveSkill — embedded content", () => {
+  it("returns embedded content when present", () => {
+    const wf = baseWorkflow({
+      "spec-driven-development": { content: "# Embedded skill\n\nDo specs first." },
+    });
+    const result = resolveSkill("spec-driven-development", wf, "/tmp/wf.json");
+    expect(result?.content).toBe("# Embedded skill\n\nDo specs first.");
+    expect(result?.origin).toBe("embedded");
+  });
+
+  it("returns null when skill name not in workflow and no other source available", () => {
+    const wf = baseWorkflow({});
+    const result = resolveSkill("missing-skill", wf, "/tmp/nonexistent-dir/wf.json");
+    expect(result).toBeNull();
+  });
+});

--- a/tests/skillResolver.test.ts
+++ b/tests/skillResolver.test.ts
@@ -1,9 +1,25 @@
 import { describe, expect, it } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { resolveSkill } from "../src/skillResolver.ts";
 import type { WorkflowDefinition } from "../src/types.ts";
 
 function baseWorkflow(skills: WorkflowDefinition["skills"] = {}): WorkflowDefinition {
   return { key: "wf", title: "wf", steps: [], skills };
+}
+
+function withTempWorkflow(skillContent: string, fn: (workflowFile: string, skillFile: string) => void): void {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wm-skill-"));
+  const skillFile = path.join(dir, "MY_SKILL.md");
+  const workflowFile = path.join(dir, "wf.json");
+  fs.writeFileSync(skillFile, skillContent);
+  fs.writeFileSync(workflowFile, "{}");
+  try {
+    fn(workflowFile, skillFile);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 }
 
 describe("resolveSkill — embedded content", () => {
@@ -19,6 +35,38 @@ describe("resolveSkill — embedded content", () => {
   it("returns null when skill name not in workflow and no other source available", () => {
     const wf = baseWorkflow({});
     const result = resolveSkill("missing-skill", wf, "/tmp/nonexistent-dir/wf.json");
+    expect(result).toBeNull();
+  });
+});
+
+describe("resolveSkill — workflow source path", () => {
+  it("reads content from skills[name].source path relative to workflow file", () => {
+    withTempWorkflow("# From source\n\nLoaded from path.", (workflowFile, _skillFile) => {
+      const wf = baseWorkflow({
+        "my-skill": { source: "./MY_SKILL.md" },
+      });
+      const result = resolveSkill("my-skill", wf, workflowFile);
+      expect(result?.content).toBe("# From source\n\nLoaded from path.");
+      expect(result?.origin).toBe("source");
+    });
+  });
+
+  it("prefers embedded content over source path when both present", () => {
+    withTempWorkflow("# from disk", (workflowFile, _skillFile) => {
+      const wf = baseWorkflow({
+        "my-skill": { source: "./MY_SKILL.md", content: "# embedded wins" },
+      });
+      const result = resolveSkill("my-skill", wf, workflowFile);
+      expect(result?.content).toBe("# embedded wins");
+      expect(result?.origin).toBe("embedded");
+    });
+  });
+
+  it("returns null when source path does not exist", () => {
+    const wf = baseWorkflow({
+      "my-skill": { source: "./does-not-exist.md" },
+    });
+    const result = resolveSkill("my-skill", wf, "/tmp/nonexistent-dir/wf.json");
     expect(result).toBeNull();
   });
 });

--- a/tests/skillResolver.test.ts
+++ b/tests/skillResolver.test.ts
@@ -70,3 +70,34 @@ describe("resolveSkill — workflow source path", () => {
     expect(result).toBeNull();
   });
 });
+
+describe("resolveSkill — project local tier", () => {
+  it("reads from <workflowDir>/skills/<name>/SKILL.md", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wm-skill-"));
+    try {
+      const skillDir = path.join(dir, "skills", "local-skill");
+      fs.mkdirSync(skillDir, { recursive: true });
+      fs.writeFileSync(path.join(skillDir, "SKILL.md"), "# Project local skill");
+      const workflowFile = path.join(dir, "wf.json");
+      fs.writeFileSync(workflowFile, "{}");
+
+      const result = resolveSkill("local-skill", baseWorkflow(), workflowFile);
+      expect(result?.content).toBe("# Project local skill");
+      expect(result?.origin).toBe("project-local");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("resolveSkill — name safety", () => {
+  it("rejects names with path traversal segments", () => {
+    const result = resolveSkill("../../etc/passwd", baseWorkflow(), "/tmp/wf.json");
+    expect(result).toBeNull();
+  });
+
+  it("rejects names with absolute path indicators", () => {
+    const result = resolveSkill("/etc/passwd", baseWorkflow(), "/tmp/wf.json");
+    expect(result).toBeNull();
+  });
+});

--- a/tests/story-workflow.e2e.test.ts
+++ b/tests/story-workflow.e2e.test.ts
@@ -21,7 +21,7 @@ function withAdapter(workflow: WorkflowDefinition, adapterKey: "mock" | "opencod
   };
 }
 
-function runStoryWorkflow(workflowPath: string, adapterKey: "mock" | "opencode" = "mock") {
+async function runStoryWorkflow(workflowPath: string, adapterKey: "mock" | "opencode" = "mock") {
   const inputPath = path.resolve("tests/fixtures/story-input.json");
   const input = JSON.parse(fs.readFileSync(inputPath, "utf-8")) as Record<string, unknown>;
   const workflow = withAdapter(parseWorkflowFile(path.resolve(workflowPath)), adapterKey);
@@ -29,7 +29,7 @@ function runStoryWorkflow(workflowPath: string, adapterKey: "mock" | "opencode" 
   return runWorkflow(workflow, { input, autoConfirmAll: true });
 }
 
-function assertStoryResult(result: ReturnType<typeof runWorkflow>, adapterKey: "mock" | "opencode"): void {
+function assertStoryResult(result: Awaited<ReturnType<typeof runWorkflow>>, adapterKey: "mock" | "opencode"): void {
   expect(result.status).toBe("succeeded");
   expect(result.events.some((event) => event.type === "run.failed")).toBe(false);
 
@@ -56,23 +56,23 @@ function assertStoryResult(result: ReturnType<typeof runWorkflow>, adapterKey: "
 }
 
 describe("story workflow e2e", () => {
-  it("runs the story workflow from JSON", () => {
-    const result = runStoryWorkflow("tests/fixtures/story-workflow.json");
+  it("runs the story workflow from JSON", async () => {
+    const result = await runStoryWorkflow("tests/fixtures/story-workflow.json");
     assertStoryResult(result, "mock");
   });
 
-  it("runs the story workflow from Markdown", () => {
-    const result = runStoryWorkflow("tests/fixtures/story-workflow.md");
+  it("runs the story workflow from Markdown", async () => {
+    const result = await runStoryWorkflow("tests/fixtures/story-workflow.md");
     assertStoryResult(result, "mock");
   });
 
-  it("runs the JSON story workflow using opencode adapter", () => {
-    const result = runStoryWorkflow("tests/fixtures/story-workflow.json", "opencode");
+  it("runs the JSON story workflow using opencode adapter", async () => {
+    const result = await runStoryWorkflow("tests/fixtures/story-workflow.json", "opencode");
     assertStoryResult(result, "opencode");
   });
 
-  it("runs the Markdown story workflow using opencode adapter", () => {
-    const result = runStoryWorkflow("tests/fixtures/story-workflow.md", "opencode");
+  it("runs the Markdown story workflow using opencode adapter", async () => {
+    const result = await runStoryWorkflow("tests/fixtures/story-workflow.md", "opencode");
     assertStoryResult(result, "opencode");
   });
 });


### PR DESCRIPTION
## Summary

This PR evolves skill resolution to a **portable + auditable** model while keeping workflow orchestration deterministic.

- Workflows remain the orchestrator (step graph, retries, approvals, adapters).
- Skills are prompt inputs only.
- Publish creates portable artifacts by inlining skill content.
- Runtime enforces stricter local-source safety rules.

## Authoring vs Artifact Contract

### Authoring (local)
- Workflow may reference local skill files via `skills[name].source`.
- Allowed source shape: `./skills/**/SKILL.md` only.

### Published artifact (registry)
- `publish` materializes skill markdown into `skills[name].content`.
- `publish` computes and writes `skills[name].contentSha256`.
- Optional provenance metadata is preserved in `skills[name].upstream`.

## Flow Diagram

```mermaid
flowchart TD
  A["Local workflow authoring<br/>skill source under ./skills/.../SKILL.md"] --> B["workflow-manager publish"]
  B --> C["Bundle skills"]
  C --> C1["Inline skill content"]
  C --> C2["Compute content SHA-256"]
  C --> C3["Preserve upstream metadata"]
  C --> D["Registry artifact JSON"]
  D --> E["workflow-manager pull"]
  E --> F["Validate workflow and skill policy"]
  F --> G{"Any declared skill missing embedded content?"}
  G -- yes --> H["Reject pull"]
  G -- no --> I["Write local file"]
  I --> J["workflow-manager run"]
  J --> K["Resolver order: embedded, safe source, project local, user global, npm"]
```

## Security Hardening in This PR

1. Added `SkillEntry` metadata:
   - `upstream?: { repo?, ref?, path? }`
   - `contentSha256?: string`
2. Validation now rejects:
   - unsafe skill names
   - skill `source` outside `./skills/**/SKILL.md`
   - malformed or mismatched `contentSha256`
3. Resolver now fails closed for explicit unsafe `source` entries.
4. Pull now rejects workflows with a `skills` map if any declared skill lacks embedded `content`.

This preserves portability for pulled workflows and reduces local file exfiltration risk from arbitrary source paths.

## Resolver Behavior

`resolveSkill(name, workflow, workflowFilePath)` resolves in order:

1. Embedded `skills[name].content`
2. Explicit local source `skills[name].source` (restricted to `./skills/**/SKILL.md`)
3. Project local fallback `./skills/<name>/SKILL.md`
4. User-global fallback `~/.workflow-manager/skills/<name>/SKILL.md`
5. Packaged npm fallback under `node_modules/workflow-manager/skills/<name>/SKILL.md`

## Publish / Pull Behavior

- `cmdPublish` now bundles skills with `content` + `contentSha256`.
- `cmdPull` validates pulled workflows and rejects workflows with a `skills` map if any declared skill is missing embedded `content`.

## Test Coverage Delta

- Baseline: **57** passing unit tests
- After this PR: **80** passing unit tests

Added/expanded coverage:
- `tests/skillResolver.test.ts`
  - source policy + fail-closed behavior
- `tests/publish-bundle.test.ts`
  - hash generation, source policy, upstream metadata preservation
- `tests/parser.test.ts`
  - source policy and hash integrity validation
- `tests/remote.test.ts`
  - publish includes inlined content/hash
  - pull rejects non-embedded skill workflows

## Verification

```bash
bun run test:unit
# 80 pass, 0 fail
```

## Stacked PR

This PR is stacked on top of #22 (`raheed/claude-code-executor`). Merge order: #22 -> #23.

