### PR TITLE
Package bundled skills and fix remote owner fallback

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,72 @@
+name: Publish npm package
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "README.md"
+      - "package.json"
+      - "tsconfig.json"
+      - "bun.lockb"
+      - "src/**"
+      - "skills/**"
+      - "man/**"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run tests
+        run: bun test
+
+      - name: Build package
+        run: bun run build
+
+      - name: Check published version
+        id: version_check
+        run: |
+          LOCAL_VERSION=$(node -p "require('./package.json').version")
+          PUBLISHED_VERSION=$(npm view @workflow-manager/runner version 2>/dev/null || true)
+          echo "local_version=$LOCAL_VERSION" >> "$GITHUB_OUTPUT"
+          echo "published_version=$PUBLISHED_VERSION" >> "$GITHUB_OUTPUT"
+          if [ "$LOCAL_VERSION" = "$PUBLISHED_VERSION" ]; then
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm
+        if: steps.version_check.outputs.should_publish == 'true'
+        run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Skip duplicate publish
+        if: steps.version_check.outputs.should_publish != 'true'
+        run: |
+          echo "Skipping npm publish because @workflow-manager/runner@${{ steps.version_check.outputs.local_version }} is already published."
+          echo "Bump package.json version in the PR to publish a new release."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,13 @@ jobs:
         include:
           - os: macos-latest
             target: bun-darwin-arm64
-            output: workflow-manager-macos-arm64
+            output: wfm-macos-arm64
           - os: ubuntu-latest
             target: bun-linux-x64
-            output: workflow-manager-linux-x64
+            output: wfm-linux-x64
           - os: windows-latest
             target: bun-windows-x64
-            output: workflow-manager-windows-x64.exe
+            output: wfm-windows-x64.exe
 
     runs-on: ${{ matrix.os }}
 
@@ -68,6 +68,6 @@ jobs:
         with:
           generate_release_notes: true
           files: |
-            ./release-assets/workflow-manager-macos-arm64/workflow-manager-macos-arm64
-            ./release-assets/workflow-manager-linux-x64/workflow-manager-linux-x64
-            ./release-assets/workflow-manager-windows-x64.exe/workflow-manager-windows-x64.exe
+            ./release-assets/wfm-macos-arm64/wfm-macos-arm64
+            ./release-assets/wfm-linux-x64/wfm-linux-x64
+            ./release-assets/wfm-windows-x64.exe/wfm-windows-x64.exe

--- a/README.md
+++ b/README.md
@@ -31,20 +31,20 @@ bun install
 bun run build
 bun link
 
-workflow-manager scaffold ./example-workflow.md
-workflow-manager validate ./example-workflow.md
-workflow-manager run ./example-workflow.md --auto-confirm-all
+wfm scaffold ./example-workflow.md
+wfm validate ./example-workflow.md
+wfm run ./example-workflow.md --auto-confirm-all
 
 # JSON workflow support
-workflow-manager scaffold ./example-workflow.json --format json
-workflow-manager validate ./example-workflow.json
-workflow-manager run ./example-workflow.json --auto-confirm-all
+wfm scaffold ./example-workflow.json --format json
+wfm validate ./example-workflow.json
+wfm run ./example-workflow.json --auto-confirm-all
 
 # Remote registry
-workflow-manager auth login --token <token>
-workflow-manager search bunny
-workflow-manager publish ./example-workflow.json --visibility public --tag storytelling,example
-workflow-manager pull alice/remote-bunny --output ./remote-bunny.json
+wfm auth login --token <token>
+wfm search bunny
+wfm publish ./example-workflow.json --visibility public --tag storytelling,example
+wfm pull alice/remote-bunny --output ./remote-bunny.json
 ```
 
 ## Build
@@ -118,29 +118,29 @@ bun run remote-registry:build
 Manual help:
 
 ```bash
-workflow-manager man
+wfm man
 ```
 
 Remote registry commands:
 
 ```bash
-workflow-manager auth whoami
-workflow-manager auth logout
-workflow-manager remote info alice/remote-bunny
+wfm auth whoami
+wfm auth logout
+wfm remote info alice/remote-bunny
 ```
 
 ## Agent skills
 
-The published `workflow-manager` npm package now ships the CLI runner and the bundled agent skills together.
+The published `@workflow-manager/runner` npm package now ships the CLI runner and the bundled agent skills together.
 
 - bundled skill: `skills/workflow-manager-cli/SKILL.md`
 - discovery keyword: `tanstack-intent`
-- install flow: install `workflow-manager`, then run `npx @tanstack/intent@latest list` and `npx @tanstack/intent@latest install`
+- install flow: install `@workflow-manager/runner`, then run `npx @tanstack/intent@latest list` and `npx @tanstack/intent@latest install`
 
 Example usage:
 
 ```bash
-npm install workflow-manager
+npm install @workflow-manager/runner
 npx @tanstack/intent@latest list
 npx @tanstack/intent@latest install
 ```
@@ -177,11 +177,14 @@ The docs site is no longer the auto-release target and should be deployed manual
 ## Release
 
 - Push a semantic tag like `v0.2.0` to trigger the GitHub Actions release workflow.
+- Merges to `main` that change the packaged CLI paths now trigger `.github/workflows/npm-publish.yml` to publish `@workflow-manager/runner` to npm.
+- The npm publish job skips automatically if the version in `package.json` is already published, so bump the package version in the PR for each release.
+- Configure the repository `NPM_TOKEN` secret with an npm automation token that can publish `@workflow-manager/runner`.
 - Publish the root npm package when you want the CLI runner and `skills/` bundle to ship together.
 - The workflow runs tests and build, then compiles binaries for:
-  - macOS arm64: `workflow-manager-macos-arm64`
-  - Linux x64: `workflow-manager-linux-x64`
-  - Windows x64: `workflow-manager-windows-x64.exe`
+  - macOS arm64: `wfm-macos-arm64`
+  - Linux x64: `wfm-linux-x64`
+  - Windows x64: `wfm-windows-x64.exe`
 - Assets are attached to the GitHub Release for that tag.
 
 ## Documentation

--- a/apps/remote-registry/src/lib/remoteApi.ts
+++ b/apps/remote-registry/src/lib/remoteApi.ts
@@ -39,9 +39,11 @@ export function searchWorkflows(query: string): Promise<SearchResponse> {
   return callFunction<SearchResponse>(`search-workflows?${params.toString()}`);
 }
 
-export function getWorkflow(owner: string, slug: string): Promise<WorkflowDetail> {
+export function getWorkflow(owner: string, slug: string, accessToken?: string): Promise<WorkflowDetail> {
   const params = new URLSearchParams({ owner, slug });
-  return callFunction<WorkflowDetail>(`pull-workflow?${params.toString()}`);
+  return callFunction<WorkflowDetail>(`pull-workflow?${params.toString()}`, {
+    headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : undefined,
+  });
 }
 
 export function createCliToken(accessToken: string, name: string): Promise<TokenSummary> {

--- a/apps/remote-registry/src/pages/DashboardPage.tsx
+++ b/apps/remote-registry/src/pages/DashboardPage.tsx
@@ -78,13 +78,13 @@ export function DashboardPage() {
     return <Navigate to="/auth" replace />;
   }
 
-  const owner = profile.data?.username ?? "owner";
+  const owner = profile.data?.username ?? profile.data?.userId ?? "owner";
 
   return (
     <div className="stack-lg">
       <div className="stack-sm">
         <Eyebrow>Dashboard</Eyebrow>
-        <h1>Welcome back, {profile.data?.displayName ?? profile.data?.username ?? "creator"}.</h1>
+        <h1>Welcome back, {profile.data?.displayName ?? profile.data?.username ?? profile.data?.userId ?? "creator"}.</h1>
         <p className="muted" style={{ maxWidth: "70ch" }}>
           Mint CLI tokens, publish new workflow versions, and watch downloads across your registry content.
         </p>

--- a/apps/remote-registry/src/pages/WorkflowDetailPage.tsx
+++ b/apps/remote-registry/src/pages/WorkflowDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useParams } from "react-router-dom";
 import { FileCode2, Hash } from "lucide-react";
+import { useAuth } from "../auth/useAuth";
 import { getWorkflow } from "../lib/remoteApi";
 import { CodeBlock } from "../ui/CodeBlock";
 import { Eyebrow } from "../ui/Panel";
@@ -8,11 +9,12 @@ import { Pill } from "../ui/Pill";
 import { StatusBanner } from "../ui/StatusBanner";
 
 export function WorkflowDetailPage() {
+  const { loading, session } = useAuth();
   const { owner = "", slug = "" } = useParams();
   const workflow = useQuery({
-    queryKey: ["workflow", owner, slug],
-    queryFn: () => getWorkflow(owner, slug),
-    enabled: Boolean(owner && slug),
+    queryKey: ["workflow", owner, slug, session?.access_token ?? null],
+    queryFn: () => getWorkflow(owner, slug, session?.access_token),
+    enabled: Boolean(owner && slug) && !loading,
   });
 
   if (workflow.isLoading) {

--- a/doc/guide/architecture.md
+++ b/doc/guide/architecture.md
@@ -27,7 +27,7 @@ For now, these layers run in-process inside the CLI. The contracts are separated
 - `WorkflowDefinition`: normalized in-memory representation of frontmatter
 - `InputEnvelope`: data passed to a step executor
 - `OutputEnvelope`: structured result returned by a step executor
-- `RunResult`: final output returned by `workflow-manager run`
+- `RunResult`: final output returned by `wfm run`
 
 ## Runtime design choices
 

--- a/doc/guide/getting-started.md
+++ b/doc/guide/getting-started.md
@@ -11,42 +11,42 @@ bun link
 ## Core CLI commands
 
 ```bash
-workflow-manager questions
-workflow-manager scaffold ./example-workflow.md
-workflow-manager validate ./example-workflow.md
-workflow-manager run ./example-workflow.md --confirm discover,qa_gate:human
+wfm questions
+wfm scaffold ./example-workflow.md
+wfm validate ./example-workflow.md
+wfm run ./example-workflow.md --confirm discover,qa_gate:human
 
 # JSON workflow files
-workflow-manager scaffold ./example-workflow.json --format json
-workflow-manager validate ./example-workflow.json
-workflow-manager run ./example-workflow.json --confirm discover,qa_gate:human
+wfm scaffold ./example-workflow.json --format json
+wfm validate ./example-workflow.json
+wfm run ./example-workflow.json --confirm discover,qa_gate:human
 
 # Manual help
-workflow-manager man
+wfm man
 
 # Remote registry
-workflow-manager auth login --token <token>
-workflow-manager auth whoami
-workflow-manager search bunny
-workflow-manager publish ./example-workflow.json --visibility public
-workflow-manager pull alice/remote-bunny --output ./remote-bunny.json
+wfm auth login --token <token>
+wfm auth whoami
+wfm search bunny
+wfm publish ./example-workflow.json --visibility public
+wfm pull alice/remote-bunny --output ./remote-bunny.json
 ```
 
 ## Typical workflow
 
-1. Run `workflow-manager questions` to gather design requirements for a new workflow.
-2. Run `workflow-manager scaffold ./example-workflow.md` to generate a starter file.
+1. Run `wfm questions` to gather design requirements for a new workflow.
+2. Run `wfm scaffold ./example-workflow.md` to generate a starter file.
 3. Edit frontmatter (Markdown) or JSON fields with your steps, dependencies, validation, and adapter init config.
-4. Run `workflow-manager validate ./example-workflow.md` or `workflow-manager validate ./example-workflow.json` until validation passes.
-5. Run `workflow-manager run <workflow-file>` and inspect the JSON run report.
+4. Run `wfm validate ./example-workflow.md` or `wfm validate ./example-workflow.json` until validation passes.
+5. Run `wfm run <workflow-file>` and inspect the JSON run report.
 
 ## Remote registry workflow
 
 1. Sign into the web app and create a CLI token.
-2. Run `workflow-manager auth login --token <token>` locally.
-3. Publish with `workflow-manager publish <workflow-file>`.
-4. Discover workflows with `workflow-manager search <query>`.
-5. Pull a shared workflow with `workflow-manager pull <owner/slug>` and run it locally.
+2. Run `wfm auth login --token <token>` locally.
+3. Publish with `wfm publish <workflow-file>`.
+4. Discover workflows with `wfm search <query>`.
+5. Pull a shared workflow with `wfm pull <owner/slug>` and run it locally.
 
 ## Run docs locally
 
@@ -88,7 +88,7 @@ Primary routes:
 
 ```bash
 bun run build:bin
-./dist/workflow-manager --help
+./dist/wfm --help
 ```
 
 ## Release binaries

--- a/doc/guide/workflow-examples.md
+++ b/doc/guide/workflow-examples.md
@@ -72,13 +72,13 @@ steps:
 
 ```bash
 # Validate structure
-workflow-manager validate ./release-flow.md
+wfm validate ./release-flow.md
 
 # Run with explicit confirmations
-workflow-manager run ./release-flow.md --confirm build:external,qa_gate:human
+wfm run ./release-flow.md --confirm build:external,qa_gate:human
 
 # Fast path for local testing
-workflow-manager run ./release-flow.md --auto-confirm-all
+wfm run ./release-flow.md --auto-confirm-all
 ```
 
 ## Implementation patterns

--- a/doc/remote-registry/index.md
+++ b/doc/remote-registry/index.md
@@ -136,13 +136,13 @@ Responsibilities:
 
 Planned commands:
 
-- `workflow-manager auth login --token <token>`
-- `workflow-manager auth whoami`
-- `workflow-manager auth logout`
-- `workflow-manager publish <file>`
-- `workflow-manager pull <owner/slug>`
-- `workflow-manager search <query>`
-- `workflow-manager remote info <owner/slug>`
+- `wfm auth login --token <token>`
+- `wfm auth whoami`
+- `wfm auth logout`
+- `wfm publish <file>`
+- `wfm pull <owner/slug>`
+- `wfm search <query>`
+- `wfm remote info <owner/slug>`
 
 ### 2. Web App
 

--- a/man/wfm.1
+++ b/man/wfm.1
@@ -1,12 +1,12 @@
-.TH WORKFLOW-MANAGER 1 "April 2026" "workflow-manager" "User Commands"
+.TH WFM 1 "April 2026" "@workflow-manager/runner" "User Commands"
 .SH NAME
-workflow-manager \- run markdown or json workflows from the CLI
+wfm \- run markdown or json workflows from the CLI
 .SH SYNOPSIS
-.B workflow-manager
+.B wfm
 .I command
 [options]
 .SH DESCRIPTION
-workflow-manager parses a workflow definition file, validates it, and executes
+wfm parses a workflow definition file, validates it, and executes
 it with deterministic in-memory orchestration.
 
 Workflow files can be Markdown with YAML frontmatter or JSON.
@@ -58,31 +58,31 @@ Bypass confirmation gating for all steps.
 .SH EXAMPLES
 .TP
 Validate markdown workflow:
-.B workflow-manager validate ./example-workflow.md
+.B wfm validate ./example-workflow.md
 .TP
 Validate json workflow:
-.B workflow-manager validate ./example-workflow.json
+.B wfm validate ./example-workflow.json
 .TP
 Scaffold json workflow file:
-.B workflow-manager scaffold ./new-workflow.json --format json
+.B wfm scaffold ./new-workflow.json --format json
 .TP
 Authenticate with a CLI token:
-.B workflow-manager auth login --token wm_exampletoken
+.B wfm auth login --token wm_exampletoken
 .TP
 Publish a workflow:
-.B workflow-manager publish ./example-workflow.json --visibility public --tag example,automation
+.B wfm publish ./example-workflow.json --visibility public --tag example,automation
 .TP
 Pull a remote workflow:
-.B workflow-manager pull alice/remote-bunny --output ./remote-bunny.json
+.B wfm pull alice/remote-bunny --output ./remote-bunny.json
 .TP
 Search the remote registry:
-.B workflow-manager search bunny
+.B wfm search bunny
 .TP
 Run with explicit confirmations:
-.B workflow-manager run ./example-workflow.json --confirm discover:human,qa_gate:human
+.B wfm run ./example-workflow.json --confirm discover:human,qa_gate:human
 .SH FILES
 .TP
-.B man/workflow-manager.1
+.B man/wfm.1
 The manual page source shipped with this repository.
 .SH EXIT STATUS
 .TP

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
-  "name": "workflow-manager",
+  "name": "@workflow-manager/runner",
   "version": "0.1.0",
   "description": "CLI runner for in-memory and markdown workflow orchestration using ATEP-like envelopes",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "workflow-manager": "dist/index.js"
+    "wfm": "dist/index.js"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "files": [
     "dist/",
@@ -15,12 +18,12 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "build:bin": "bun build ./src/index.ts --compile --outfile ./dist/workflow-manager",
-    "build:bin:macos": "bun build ./src/index.ts --compile --target bun-darwin-arm64 --outfile ./dist/workflow-manager-macos-arm64",
-    "build:bin:linux": "bun build ./src/index.ts --compile --target bun-linux-x64 --outfile ./dist/workflow-manager-linux-x64",
-    "build:bin:windows": "bun build ./src/index.ts --compile --target bun-windows-x64 --outfile ./dist/workflow-manager-windows-x64.exe",
+    "build:bin": "bun build ./src/index.ts --compile --outfile ./dist/wfm",
+    "build:bin:macos": "bun build ./src/index.ts --compile --target bun-darwin-arm64 --outfile ./dist/wfm-macos-arm64",
+    "build:bin:linux": "bun build ./src/index.ts --compile --target bun-linux-x64 --outfile ./dist/wfm-linux-x64",
+    "build:bin:windows": "bun build ./src/index.ts --compile --target bun-windows-x64 --outfile ./dist/wfm-windows-x64.exe",
     "build:bin:all": "bun run build:bin:macos && bun run build:bin:linux && bun run build:bin:windows",
-    "man": "man ./man/workflow-manager.1",
+    "man": "man ./man/wfm.1",
     "test:unit": "bun test tests/parser.test.ts tests/engine.test.ts tests/mockExecutor.test.ts tests/opencodeExecutor.test.ts tests/remote.test.ts tests/run-telemetry.test.ts tests/supabase-functions.test.ts tests/supabase-ops.test.ts tests/remote-registry-app.test.ts",
     "test:e2e": "bun test tests/story-workflow.e2e.test.ts tests/opencode-real.e2e.test.ts",
     "test:e2e:real": "WORKFLOW_MANAGER_REAL_OPENCODE=1 bun test tests/opencode-real.e2e.test.ts",

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,6 +1,6 @@
 # workflow-manager skills
 
-`workflow-manager` now ships its TanStack Intent-compatible skills in the main npm package.
+`@workflow-manager/runner` now ships its TanStack Intent-compatible skills in the main npm package.
 
 The first bundled skill is `workflow-manager-cli`, which teaches agents how to:
 
@@ -15,7 +15,7 @@ The first bundled skill is `workflow-manager-cli`, which teaches agents how to:
 Install the main package in the project where you want the CLI and skill available:
 
 ```bash
-npm install workflow-manager
+npm install @workflow-manager/runner
 ```
 
 Then use TanStack Intent to discover and map the shipped skill into your agent configuration:
@@ -25,13 +25,13 @@ npx @tanstack/intent@latest list
 npx @tanstack/intent@latest install
 ```
 
-Intent writes task-to-skill mappings into `AGENTS.md`-style config files and points them at the installed package path under `node_modules/workflow-manager/skills/...`.
+Intent writes task-to-skill mappings into `AGENTS.md`-style config files and points them at the installed package path under `node_modules/@workflow-manager/runner/skills/...`.
 
 ## Packaged skill
 
 - skill path: `skills/workflow-manager-cli/SKILL.md`
 - package keyword: `tanstack-intent`
-- published with: the root `workflow-manager` npm package
+- published with: the root `@workflow-manager/runner` npm package
 
 ## Local development
 

--- a/skills/workflow-manager-cli/README.md
+++ b/skills/workflow-manager-cli/README.md
@@ -1,6 +1,6 @@
 # workflow-manager-cli skill
 
-This skill ships inside the root `workflow-manager` npm package.
+This skill ships inside the root `@workflow-manager/runner` npm package.
 
 It is designed for TanStack Intent discovery and should stay aligned with the CLI behavior documented in:
 

--- a/skills/workflow-manager-cli/SKILL.md
+++ b/skills/workflow-manager-cli/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: workflow-manager/workflow-manager-cli
+name: @workflow-manager/runner/cli
 description: >
-  Load this skill when working with the workflow-manager CLI, authoring or
+  Load this skill when working with the wfm CLI from @workflow-manager/runner, authoring or
   validating workflow definitions, configuring step skills and adapters, or
   publishing workflows to the remote registry. Covers questions, scaffold,
   validate, run, auth, publish, pull, search, and remote info.
 type: core
-library: workflow-manager
+library: @workflow-manager/runner
 library_version: "0.1.0"
 sources:
   - "navio/workflow-manager:README.md"
@@ -16,9 +16,9 @@ sources:
   - "navio/workflow-manager:src/remote/commands.ts"
 ---
 
-# workflow-manager CLI
+# wfm CLI
 
-Use this skill when you need to create or operate `workflow-manager` workflows from the terminal.
+Use this skill when you need to create or operate `workflow-manager` workflows from the terminal with `wfm`.
 
 ## When to use this skill
 
@@ -35,39 +35,39 @@ Use it when the user wants to:
 
 Use this sequence unless the user asks for a narrower task:
 
-1. Discover the workflow intent with `workflow-manager questions`
-2. Scaffold a starter file with `workflow-manager scaffold`
+1. Discover the workflow intent with `wfm questions`
+2. Scaffold a starter file with `wfm scaffold`
 3. Edit the workflow definition
-4. Validate the file with `workflow-manager validate`
-5. Execute it with `workflow-manager run`
+4. Validate the file with `wfm validate`
+5. Execute it with `wfm run`
 6. If needed, authenticate and publish with the remote registry commands
 
 ## Local workflow commands
 
 ```bash
-workflow-manager questions
+wfm questions
 
-workflow-manager scaffold ./example-workflow.md
-workflow-manager scaffold ./example-workflow.json --format json
+wfm scaffold ./example-workflow.md
+wfm scaffold ./example-workflow.json --format json
 
-workflow-manager validate ./example-workflow.md
-workflow-manager validate ./example-workflow.json
+wfm validate ./example-workflow.md
+wfm validate ./example-workflow.json
 
-workflow-manager run ./example-workflow.md --confirm discover,qa_gate:human
-workflow-manager run ./example-workflow.json --auto-confirm-all
+wfm run ./example-workflow.md --confirm discover,qa_gate:human
+wfm run ./example-workflow.json --auto-confirm-all
 ```
 
 ## Remote registry commands
 
 ```bash
-workflow-manager auth login --token <token>
-workflow-manager auth whoami
-workflow-manager auth logout
+wfm auth login --token <token>
+wfm auth whoami
+wfm auth logout
 
-workflow-manager search bunny
-workflow-manager remote info alice/remote-bunny
-workflow-manager publish ./example-workflow.json --visibility public --tag storytelling,example
-workflow-manager pull alice/remote-bunny --output ./remote-bunny.json
+wfm search bunny
+wfm remote info alice/remote-bunny
+wfm publish ./example-workflow.json --visibility public --tag storytelling,example
+wfm pull alice/remote-bunny --output ./remote-bunny.json
 ```
 
 ## Skill guidance
@@ -106,6 +106,6 @@ workflow-manager pull alice/remote-bunny --output ./remote-bunny.json
 ## Typical troubleshooting
 
 - If validation fails, inspect the reported schema or dependency error before running again
-- If `publish` fails, confirm the user is logged in with `workflow-manager auth whoami`
+- If `publish` fails, confirm the user is logged in with `wfm auth whoami`
 - If remote calls fail in the browser, verify the remote registry app has valid Supabase `VITE_*` environment variables
 - If a real adapter test fails, confirm the underlying external CLI is installed and available on `PATH`

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ const DISCOVERY_QUESTIONS = [
 ];
 
 function usage(): void {
-  console.log(`workflow-manager commands:
+  console.log(`wfm commands:
   questions
   scaffold [path] [--format markdown|json]
   validate <workflow.md|workflow.json>
@@ -278,7 +278,7 @@ function cmdScaffold(targetPath?: string, format?: string): number {
 }
 
 function cmdMan(): number {
-  const manPagePath = path.resolve("./man/workflow-manager.1");
+  const manPagePath = path.resolve("./man/wfm.1");
 
   if (!fs.existsSync(manPagePath)) {
     console.error(`Man page not found at ${manPagePath}`);

--- a/src/remote/api.ts
+++ b/src/remote/api.ts
@@ -121,7 +121,7 @@ function buildHeaders(body?: unknown, token?: string): HeadersInit {
 async function remoteFetch<T>(path: string, init: RequestInit = {}, requireAuth = false): Promise<T> {
   const token = resolveAuthToken();
   if (requireAuth && !token) {
-    throw new Error("Not authenticated. Run `workflow-manager auth login --token <token>` first.");
+    throw new Error("Not authenticated. Run `wfm auth login --token <token>` first.");
   }
 
   const res = await fetch(`${remoteBaseUrl()}/functions/v1/${path}`, {

--- a/src/remote/commands.ts
+++ b/src/remote/commands.ts
@@ -84,7 +84,7 @@ export async function cmdAuth(args: string[]): Promise<number> {
     return 0;
   }
 
-  console.error("Usage: workflow-manager auth <login|whoami|logout>");
+  console.error("Usage: wfm auth <login|whoami|logout>");
   return 1;
 }
 

--- a/supabase/functions/_shared/owner-resolution.ts
+++ b/supabase/functions/_shared/owner-resolution.ts
@@ -1,0 +1,35 @@
+import { HttpError } from "./responses.ts";
+
+export interface OwnerProfile {
+  id: string;
+  username: string | null;
+}
+
+interface ProfileLookupResponse {
+  data: OwnerProfile | null;
+  error: { message: string } | null;
+}
+
+export interface OwnerProfileLookupService {
+  from: (table: "profiles") => {
+    select: (columns: "id, username") => {
+      eq: (column: "username" | "id", value: string) => {
+        maybeSingle: () => Promise<ProfileLookupResponse>;
+      };
+    };
+  };
+}
+
+export async function resolveOwnerProfile(service: OwnerProfileLookupService, owner: string): Promise<OwnerProfile | null> {
+  const { data: ownerByUsername, error: ownerByUsernameError } = await service.from("profiles").select("id, username").eq("username", owner).maybeSingle();
+  if (ownerByUsernameError) throw new HttpError(500, "Failed to resolve workflow owner", ownerByUsernameError.message);
+  if (ownerByUsername) return ownerByUsername;
+
+  const { data: ownerById, error: ownerByIdError } = await service.from("profiles").select("id, username").eq("id", owner).maybeSingle();
+  if (ownerByIdError) throw new HttpError(500, "Failed to resolve workflow owner", ownerByIdError.message);
+  return ownerById;
+}
+
+export function ownerIdentifier(profile: OwnerProfile): string {
+  return profile.username ?? profile.id;
+}

--- a/supabase/functions/pull-workflow/handler.ts
+++ b/supabase/functions/pull-workflow/handler.ts
@@ -1,4 +1,5 @@
 import type { AuthContext } from "../_shared/auth-types.ts";
+import { ownerIdentifier, resolveOwnerProfile } from "../_shared/owner-resolution.ts";
 import { errorResponse, handleOptions, HttpError as HttpErrorClass, jsonResponse, requireMethod } from "../_shared/responses.ts";
 
 export interface PullWorkflowDeps {
@@ -20,8 +21,7 @@ export interface PullWorkflowDeps {
 async function pullWorkflow(req: Request, authContext: AuthContext, owner: string, slug: string, versionLabel?: string) {
   const { createServiceClient } = await import("../_shared/supabase.ts");
   const service = createServiceClient();
-  const { data: ownerProfile, error: ownerError } = await service.from("profiles").select("id, username").eq("username", owner).maybeSingle();
-  if (ownerError) throw new HttpErrorClass(500, "Failed to resolve workflow owner", ownerError.message);
+  const ownerProfile = await resolveOwnerProfile(service, owner);
   if (!ownerProfile) throw new HttpErrorClass(404, "Workflow owner not found");
   const { data: namespace, error: namespaceError } = await service.from("workflow_namespaces").select("id, owner_user_id, slug, title, description, visibility, latest_version_id").eq("owner_user_id", ownerProfile.id).eq("slug", slug).maybeSingle();
   if (namespaceError) throw new HttpErrorClass(500, "Failed to load workflow namespace", namespaceError.message);
@@ -49,7 +49,7 @@ async function pullWorkflow(req: Request, authContext: AuthContext, owner: strin
   if (insertError) throw new HttpErrorClass(500, "Failed to record workflow download event", insertError.message);
   const { refreshDailyStats } = await import("../_shared/ops.ts");
   await refreshDailyStats(namespace.id, new Date().toISOString());
-  return { owner, slug: namespace.slug, title: namespace.title, description: namespace.description, visibility: isOwner ? namespace.visibility : "public", version: version.version_label, sourceFormat: version.source_format, rawSource: version.raw_source, definition: version.definition_json, changelog: version.changelog, publishedState: version.published_state, createdAt: version.created_at };
+  return { owner: ownerIdentifier(ownerProfile), slug: namespace.slug, title: namespace.title, description: namespace.description, visibility: isOwner ? namespace.visibility : "public", version: version.version_label, sourceFormat: version.source_format, rawSource: version.raw_source, definition: version.definition_json, changelog: version.changelog, publishedState: version.published_state, createdAt: version.created_at };
 }
 
 export async function handlePullWorkflow(req: Request, deps?: Partial<PullWorkflowDeps>): Promise<Response> {

--- a/tests/owner-resolution.test.ts
+++ b/tests/owner-resolution.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import { ownerIdentifier, resolveOwnerProfile } from "../supabase/functions/_shared/owner-resolution.ts";
+
+describe("owner resolution", () => {
+  it("resolves workflow owners by username before falling back to user id", async () => {
+    const calls: Array<{ column: string; value: string }> = [];
+    const service = {
+      from: () => ({
+        select: () => ({
+          eq: (column: "username" | "id", value: string) => ({
+            maybeSingle: async () => {
+              calls.push({ column, value });
+              if (column === "username") {
+                return { data: { id: "user-1", username: "alice" }, error: null };
+              }
+              return { data: null, error: null };
+            },
+          }),
+        }),
+      }),
+    };
+
+    await expect(resolveOwnerProfile(service, "alice")).resolves.toEqual({ id: "user-1", username: "alice" });
+    expect(calls).toEqual([{ column: "username", value: "alice" }]);
+  });
+
+  it("falls back to the user id when no username is set", async () => {
+    const service = {
+      from: () => ({
+        select: () => ({
+          eq: (column: "username" | "id", value: string) => ({
+            maybeSingle: async () => {
+              if (column === "username") {
+                return { data: null, error: null };
+              }
+              return { data: { id: value, username: null }, error: null };
+            },
+          }),
+        }),
+      }),
+    };
+
+    const profile = await resolveOwnerProfile(service, "user-2");
+    expect(profile).toEqual({ id: "user-2", username: null });
+    expect(ownerIdentifier(profile!)).toBe("user-2");
+  });
+});

--- a/tests/remote-registry-app.test.ts
+++ b/tests/remote-registry-app.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
+import { getWorkflow } from "../apps/remote-registry/src/lib/remoteApi";
 import { detectSourceFormat, parseWorkflowSource } from "../apps/remote-registry/src/lib/workflowSource";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
 
 describe("remote registry app workflow parsing", () => {
   it("parses JSON workflow source for dashboard publishing", () => {
@@ -41,5 +48,16 @@ steps:
 
   it("throws for invalid workflow source", () => {
     expect(() => parseWorkflowSource("not-a-workflow")).toThrow();
+  });
+
+  it("includes the session token when loading a workflow detail", async () => {
+    let authorization = "";
+    globalThis.fetch = (async (_input, init) => {
+      authorization = new Headers(init?.headers).get("Authorization") ?? "";
+      return Response.json({ owner: "alice", slug: "demo", title: "Demo", description: null, visibility: "public", version: "v1", sourceFormat: "json", rawSource: "{}", changelog: null, publishedState: "published", createdAt: new Date().toISOString() });
+    }) as typeof fetch;
+
+    await getWorkflow("alice", "demo", "access-token");
+    expect(authorization).toBe("Bearer access-token");
   });
 });


### PR DESCRIPTION
## Summary
- rename the published runner package to `wfm`, update CLI/docs/manpage references, and add npm/release automation for shipping the bundled skills package
- fix remote workflow detail and pull resolution so owners without a `profiles.username` still work via user-id fallback in the API and dashboard links
- add regression coverage for owner resolution and authenticated workflow detail fetches

## Validation
- `bun test tests/owner-resolution.test.ts tests/remote-registry-app.test.ts tests/supabase-functions.test.ts`
- `bun run build`
- `bun run remote-registry:build` *(fails in this worktree because app dependencies/types like `react` and `@tanstack/react-query` are not installed)*