### PR TITLE
docs: deploy the docs site to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,58 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "doc/**"
+      - ".github/workflows/deploy-docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build docs
+        run: bun run docs:build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: doc/.vitepress/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ bun run docs:build
 bun run docs:preview
 ```
 
-Docs can be deployed from `doc/.vitepress/dist` locally, or from Netlify when the site sets `NETLIFY_SITE_TARGET=docs`.
+Docs can be deployed from `doc/.vitepress/dist` locally, and GitHub Pages publishes them from `main` when files under `doc/` change.
 
 Remote registry app:
 
@@ -127,10 +127,7 @@ bun run remote-registry:dev
 bun run remote-registry:build
 ```
 
-Netlify can now deploy either site from this repo using the same root `netlify.toml` plus a site-specific `NETLIFY_SITE_TARGET` environment variable:
-
-- `workflow-manager-ui` -> `NETLIFY_SITE_TARGET=remote-ui`
-- `workflow-orchestrator` -> `NETLIFY_SITE_TARGET=docs`
+The docs site is published at `https://navio.github.io/workflow-manager/` via `.github/workflows/deploy-docs.yml`.
 
 Manual help:
 
@@ -181,14 +178,13 @@ Current dashboard capabilities include:
 - Update docs under `doc/` when changing schema or runtime behavior
 - Add or update tests in `tests/` when touching parser or engine logic
 
-Netlify uses the root `netlify.toml` for both connected sites:
+Netlify is reserved for `workflow-manager-ui`.
 
 - build command: `bun run netlify:build`
 - publish directory: `.netlify/deploy`
 - `workflow-manager-ui` must set `NETLIFY_SITE_TARGET=remote-ui`
-- `workflow-orchestrator` must set `NETLIFY_SITE_TARGET=docs`
 
-The build script copies the right output into the shared publish directory and only adds the SPA redirect for the remote UI.
+GitHub Pages is reserved for docs and only deploys on changes under `doc/`.
 
 ## Release
 

--- a/doc/.vitepress/config.mts
+++ b/doc/.vitepress/config.mts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vitepress";
 
 export default defineConfig({
+  base: "/workflow-manager/",
   title: "workflow-manager",
   description: "CLI runner for markdown + in-memory workflow orchestration",
   themeConfig: {


### PR DESCRIPTION
## Summary
- deploy the VitePress docs site to GitHub Pages instead of routing docs through Netlify
- set the VitePress base path for `https://navio.github.io/workflow-manager/`
- trigger docs deploys only when files under `doc/` change

## Notes
- after merge, enable GitHub Pages for this repository and select `GitHub Actions` as the source
- `workflow-manager-ui` remains the Netlify-hosted app