### PR TITLE
docs: connect the UI and docs onboarding

### DIFF
--- a/apps/remote-registry/src/pages/HomePage.tsx
+++ b/apps/remote-registry/src/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight, Download, Package, Search, SquareArrowOutUpRight, Upload } from "lucide-react";
+import { ArrowRight, BookOpenText, Download, Package, Search, SquareArrowOutUpRight, Upload } from "lucide-react";
 import { LinkButton } from "../ui/Button";
 import { CodeBlock } from "../ui/CodeBlock";
 import { Eyebrow, Panel } from "../ui/Panel";
@@ -23,6 +23,16 @@ export function HomePage() {
           <LinkButton to="/dashboard/publish" variant="ghost">
             Publish a workflow
           </LinkButton>
+          <a
+            className="btn btn--ghost"
+            href="https://navio.github.io/workflow-manager/"
+            target="_blank"
+            rel="noreferrer"
+            aria-label="Open documentation"
+          >
+            <BookOpenText size={14} strokeWidth={2} aria-hidden="true" />
+            Documentation
+          </a>
           <a
             className="btn btn--subtle"
             href="https://github.com/navio/workflow-manager"
@@ -51,12 +61,19 @@ export function HomePage() {
               <Download size={18} strokeWidth={1.75} aria-hidden="true" />
               <h2>Install the CLI, then pull workflows into any repo.</h2>
               <p className="muted">
-                Install `wfm` from the latest GitHub release, verify the binary, and start pulling published
-                workflows without cloning the full repo first.
+                Install `wfm` from npm or the latest GitHub release, then start pulling published workflows
+                without cloning the full repo first.
               </p>
             </div>
 
-            <div className="grid-2">
+            <div className="grid-3">
+              <div className="stack-sm">
+                <span className="kpi__label">npm</span>
+                <CodeBlock prompt>{`npm install -g @workflow-manager/runner
+wfm --help`}</CodeBlock>
+                <p className="muted">Use npm when you want the CLI available through your existing Node toolchain.</p>
+              </div>
+
               <div className="stack-sm">
                 <span className="kpi__label">Latest release</span>
                 <CodeBlock prompt>{`curl -fsSL https://github.com/navio/workflow-manager/releases/latest/download/workflow-manager-installer.sh | bash

--- a/doc/.vitepress/config.mts
+++ b/doc/.vitepress/config.mts
@@ -12,6 +12,7 @@ export default defineConfig({
       { text: "How It Works", link: "/guide/how-it-works" },
       { text: "Architecture", link: "/guide/architecture" },
       { text: "Remote Registry", link: "/remote-registry/" },
+      { text: "Workflow Manager UI", link: "https://workflow-manager-ui.netlify.app" },
       { text: "ERD", link: "/guide/erd" },
       { text: "Protocol", link: "/guide/protocol" },
       { text: "Workflow Schema", link: "/guide/workflow-schema" },

--- a/doc/guide/getting-started.md
+++ b/doc/guide/getting-started.md
@@ -17,6 +17,13 @@ bun run build
 bun link
 ```
 
+Install from npm instead:
+
+```bash
+npm install -g @workflow-manager/runner
+wfm --help
+```
+
 ## Core CLI commands
 
 ```bash
@@ -51,6 +58,8 @@ wfm pull alice/remote-bunny --output ./remote-bunny.json
 
 ## Remote registry workflow
 
+The hosted web app is available at [workflow-manager-ui.netlify.app](https://workflow-manager-ui.netlify.app).
+
 1. Sign into the web app and create a CLI token.
 2. Run `wfm auth login --token <token>` locally.
 3. Publish with `wfm publish <workflow-file>`.
@@ -77,6 +86,8 @@ bun run remote-registry:build
 Set up browser env values in `apps/remote-registry/.env.local` using `apps/remote-registry/.env.example`.
 
 `workflow-manager-ui` is now the Netlify auto-release target via the root `netlify.toml`. That enables Deploy Previews for PRs and production deploys for merges to `main` once the Netlify site is connected to the repository.
+
+See the live app at [workflow-manager-ui.netlify.app](https://workflow-manager-ui.netlify.app).
 
 The web app now includes:
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -2,6 +2,13 @@
 
 `workflow-manager` is a CLI for defining and executing workflows from Markdown frontmatter.
 
+```bash
+npm install -g @workflow-manager/runner
+wfm --help
+```
+
+Use the hosted remote registry at [workflow-manager-ui.netlify.app](https://workflow-manager-ui.netlify.app) to create CLI tokens, publish workflows from the browser, and inspect dashboard analytics.
+
 It is designed for agentic and human-in-the-loop execution where each step can have:
 
 - objective-driven prompts
@@ -22,6 +29,7 @@ It is designed for agentic and human-in-the-loop execution where each step can h
 
 - [Installing the CLI](/guide/installing)
 - [Getting Started](/guide/getting-started)
+- [Workflow Manager UI](https://workflow-manager-ui.netlify.app)
 - [How It Works](/guide/how-it-works)
 - [Architecture](/guide/architecture)
 - [Remote Registry Architecture](/remote-registry/)


### PR DESCRIPTION
## Summary
- add cross-links between the remote UI homepage, the docs homepage, and the getting started guide
- add npm install onboarding for `@workflow-manager/runner` alongside the existing binary install path
- expose the hosted `workflow-manager-ui` link in the VitePress nav for easier discovery

## Validation
- bun run docs:build
- bun run remote-registry:build