### PR TITLE
Clarify missing Supabase release secrets

### DIFF
--- a/.github/workflows/supabase-release.yml
+++ b/.github/workflows/supabase-release.yml
@@ -39,9 +39,19 @@ jobs:
 
       - name: Validate Supabase secrets
         run: |
-          test -n "$SUPABASE_ACCESS_TOKEN"
-          test -n "$SUPABASE_DB_PASSWORD"
-          test -n "$SUPABASE_PROJECT_ID"
+          missing=0
+
+          for secret_name in SUPABASE_ACCESS_TOKEN SUPABASE_DB_PASSWORD SUPABASE_PROJECT_ID; do
+            if [ -z "${!secret_name}" ]; then
+              echo "::error title=Missing GitHub secret::Repository secret ${secret_name} is not configured. Add it in Settings > Secrets and variables > Actions."
+              missing=1
+            fi
+          done
+
+          if [ "$missing" -ne 0 ]; then
+            echo "Supabase release is blocked until all required GitHub Actions secrets are configured."
+            exit 1
+          fi
 
       - name: Link Supabase project
         run: supabase link --project-ref "$SUPABASE_PROJECT_ID"

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ GitHub Actions now owns the production Supabase release flow:
 - `.github/workflows/supabase-validate.yml` validates `supabase/**` changes on pull requests
 - `.github/workflows/supabase-release.yml` applies migrations and deploys Edge Functions after merge to `main`
 - configure repository secrets: `SUPABASE_ACCESS_TOKEN`, `SUPABASE_DB_PASSWORD`, and `SUPABASE_PROJECT_ID`
+- if those secrets are missing, the release workflow now fails with an explicit setup error instead of a silent shell assertion
 
 The docs site is published at `https://navio.github.io/workflow-manager/` via `.github/workflows/deploy-docs.yml`.
 


### PR DESCRIPTION
## Summary
- replace the bare `test -n` checks in the Supabase release workflow with explicit GitHub Actions error annotations for each missing secret
- add a short README note that the release workflow now fails with a setup-specific error when required secrets are absent

## Why
The existing workflow failed with an unhelpful shell assertion when `SUPABASE_ACCESS_TOKEN`, `SUPABASE_DB_PASSWORD`, or `SUPABASE_PROJECT_ID` were missing. This makes the failure actionable for anyone setting up the repository.

## Validation
- bun run lint
- bun run build