### PR TITLE
fix curl installer path visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Install the latest prebuilt CLI with:
 
 ```bash
 curl -fsSL https://github.com/navio/workflow-manager/releases/latest/download/workflow-manager-installer.sh | bash
-wfm --help
 ```
+
+If `wfm` is not available immediately in the same terminal, run the shell reload command printed by the installer or open a new shell, then run `wfm --help`.
 
 ## What it does
 
@@ -81,8 +82,9 @@ Prefer the release binary instead of a source checkout:
 
 ```bash
 curl -fsSL https://github.com/navio/workflow-manager/releases/latest/download/workflow-manager-installer.sh | bash
-wfm --help
 ```
+
+If `wfm` is not available immediately in the same terminal, run the shell reload command printed by the installer or open a new shell, then run `wfm --help`.
 
 ## Build
 

--- a/doc/guide/getting-started.md
+++ b/doc/guide/getting-started.md
@@ -6,8 +6,9 @@ Install the latest published binary:
 
 ```bash
 curl -fsSL https://github.com/navio/workflow-manager/releases/latest/download/workflow-manager-installer.sh | bash
-wfm --help
 ```
+
+If `wfm` is not available immediately in the same terminal, run the shell reload command printed by the installer or open a new shell, then run `wfm --help`.
 
 Build from source instead:
 

--- a/doc/guide/installing.md
+++ b/doc/guide/installing.md
@@ -6,10 +6,10 @@
 
 ```bash
 curl -fsSL https://github.com/navio/workflow-manager/releases/latest/download/workflow-manager-installer.sh | bash
-wfm --help
 ```
 
 The installer downloads the correct release asset for the current machine and installs the binary into `~/.local/bin` by default.
+If that directory is not already on `PATH`, the installer updates a supported shell profile automatically and prints the exact reload command to run in the current terminal.
 
 ## Choose a custom install directory
 
@@ -18,6 +18,12 @@ curl -fsSL https://github.com/navio/workflow-manager/releases/latest/download/wo
 ```
 
 If the target directory is not already on `PATH`, the installer prints the shell path hint you need.
+
+To skip shell profile updates and manage `PATH` yourself:
+
+```bash
+curl -fsSL https://github.com/navio/workflow-manager/releases/latest/download/workflow-manager-installer.sh | WORKFLOW_MANAGER_INSTALL_SKIP_SHELL_SETUP=1 bash
+```
 
 ## Pin a specific release
 
@@ -33,6 +39,7 @@ curl -fsSL https://github.com/navio/workflow-manager/releases/latest/download/wo
 - `WORKFLOW_MANAGER_INSTALL_OS`: override platform detection for testing
 - `WORKFLOW_MANAGER_INSTALL_ARCH`: override architecture detection for testing
 - `WORKFLOW_MANAGER_INSTALL_BASE_URL`: alternate asset base URL for local verification
+- `WORKFLOW_MANAGER_INSTALL_SKIP_SHELL_SETUP`: set to `1` to disable automatic shell profile updates
 
 ## Supported release binaries
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,6 +7,12 @@ binary_name="${WORKFLOW_MANAGER_INSTALL_BIN_NAME:-wfm}"
 install_dir="${WORKFLOW_MANAGER_INSTALL_DIR:-${XDG_BIN_HOME:-$HOME/.local/bin}}"
 raw_os="${WORKFLOW_MANAGER_INSTALL_OS:-$(uname -s)}"
 raw_arch="${WORKFLOW_MANAGER_INSTALL_ARCH:-$(uname -m)}"
+shell_name="${SHELL##*/}"
+
+profile_file=''
+profile_source_command=''
+profile_path_line=''
+profile_update_status=''
 
 if ! command -v curl >/dev/null 2>&1; then
   printf 'error: curl is required to install wfm\n' >&2
@@ -39,6 +45,49 @@ normalize_arch() {
       return 1
       ;;
   esac
+}
+
+configure_shell_profile() {
+  case "$shell_name" in
+    zsh)
+      profile_file="$HOME/.zshrc"
+      profile_source_command="source $HOME/.zshrc"
+      profile_path_line="export PATH=\"$install_dir:\$PATH\""
+      ;;
+    bash)
+      profile_file="$HOME/.bashrc"
+      profile_source_command="source $HOME/.bashrc"
+      profile_path_line="export PATH=\"$install_dir:\$PATH\""
+      ;;
+    fish)
+      profile_file="$HOME/.config/fish/config.fish"
+      profile_source_command="source $HOME/.config/fish/config.fish"
+      profile_path_line="fish_add_path -g \"$install_dir\""
+      ;;
+    sh|dash|ash|ksh)
+      profile_file="$HOME/.profile"
+      profile_source_command=". $HOME/.profile"
+      profile_path_line="export PATH=\"$install_dir:\$PATH\""
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  mkdir -p "$(dirname "$profile_file")"
+
+  if [ -f "$profile_file" ] && grep -F "$install_dir" "$profile_file" >/dev/null 2>&1; then
+    profile_update_status='existing'
+    return 0
+  fi
+
+  {
+    printf '\n# Added by workflow-manager installer\n'
+    printf '%s\n' "$profile_path_line"
+  } >> "$profile_file"
+
+  profile_update_status='updated'
+  return 0
 }
 
 if ! os_name="$(normalize_os "$raw_os")"; then
@@ -98,7 +147,18 @@ case ":${PATH}:" in
   *":${install_dir}:"*)
     ;;
   *)
-    printf 'Add %s to PATH to run `%s` from any shell.\n' "$install_dir" "$binary_name"
+    if [ "${WORKFLOW_MANAGER_INSTALL_SKIP_SHELL_SETUP:-0}" = '1' ]; then
+      printf 'Add %s to PATH to run `%s` from any shell.\n' "$install_dir" "$binary_name"
+    elif configure_shell_profile; then
+      if [ "$profile_update_status" = 'updated' ]; then
+        printf 'Added %s to PATH in %s.\n' "$install_dir" "$profile_file"
+      else
+        printf '%s is already configured in %s.\n' "$install_dir" "$profile_file"
+      fi
+      printf 'Start a new shell or run `%s` to use `%s` right away.\n' "$profile_source_command" "$binary_name"
+    else
+      printf 'Add %s to PATH to run `%s` from any shell.\n' "$install_dir" "$binary_name"
+    fi
     ;;
 esac
 

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -54,6 +54,33 @@ async function runInstallScript(env: NodeJS.ProcessEnv): Promise<ScriptRunResult
   });
 }
 
+async function runShellCommand(command: string, env: NodeJS.ProcessEnv): Promise<ScriptRunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("bash", ["-ic", command], {
+      cwd: process.cwd(),
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout?.setEncoding("utf-8");
+    child.stderr?.setEncoding("utf-8");
+    child.stdout?.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+
+    child.on("error", reject);
+    child.on("close", (status, signal) => {
+      resolve({ status, signal, stdout, stderr });
+    });
+  });
+}
+
 describe("remote installer", () => {
   it("downloads the matching asset and installs it to the requested directory", async () => {
     const installDir = makeTempDir("wm-install-dir-");
@@ -113,5 +140,95 @@ describe("remote installer", () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("unsupported operating system: plan9");
+  });
+
+  it("adds the install directory to bash profile when PATH is missing it", async () => {
+    const installDir = makeTempDir("wm-install-dir-");
+    const homeDir = makeTempDir("wm-install-home-");
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const pathname = new URL(request.url).pathname;
+        if (pathname !== "/wfm-linux-x64") {
+          return new Response("not found", { status: 404 });
+        }
+
+        return new Response("#!/bin/sh\nprintf 'wfm test binary\\n'\n", {
+          headers: {
+            "Content-Type": "application/octet-stream",
+          },
+        });
+      },
+    });
+
+    try {
+      const result = await runInstallScript({
+        ...process.env,
+        HOME: homeDir,
+        PATH: "/usr/bin:/bin",
+        SHELL: "/bin/bash",
+        WORKFLOW_MANAGER_INSTALL_BASE_URL: `http://127.0.0.1:${server.port}`,
+        WORKFLOW_MANAGER_INSTALL_DIR: installDir,
+        WORKFLOW_MANAGER_INSTALL_OS: "linux",
+        WORKFLOW_MANAGER_INSTALL_ARCH: "x86_64",
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain(`Added ${installDir} to PATH in ${path.join(homeDir, ".bashrc")}.`);
+
+      const bashrc = path.join(homeDir, ".bashrc");
+      expect(fs.readFileSync(bashrc, "utf-8")).toContain(`export PATH="${installDir}:$PATH"`);
+
+      const shellResult = await runShellCommand("command -v wfm", {
+        ...process.env,
+        HOME: homeDir,
+        PATH: "/usr/bin:/bin",
+      });
+
+      expect(shellResult.status).toBe(0);
+      expect(shellResult.stdout.trim()).toBe(path.join(installDir, "wfm"));
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  it("prints a manual PATH hint when shell profile setup is disabled", async () => {
+    const installDir = makeTempDir("wm-install-dir-");
+    const homeDir = makeTempDir("wm-install-home-");
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const pathname = new URL(request.url).pathname;
+        if (pathname !== "/wfm-linux-x64") {
+          return new Response("not found", { status: 404 });
+        }
+
+        return new Response("#!/bin/sh\nprintf 'wfm test binary\\n'\n", {
+          headers: {
+            "Content-Type": "application/octet-stream",
+          },
+        });
+      },
+    });
+
+    try {
+      const result = await runInstallScript({
+        ...process.env,
+        HOME: homeDir,
+        PATH: "/usr/bin:/bin",
+        SHELL: "/bin/bash",
+        WORKFLOW_MANAGER_INSTALL_BASE_URL: `http://127.0.0.1:${server.port}`,
+        WORKFLOW_MANAGER_INSTALL_DIR: installDir,
+        WORKFLOW_MANAGER_INSTALL_OS: "linux",
+        WORKFLOW_MANAGER_INSTALL_ARCH: "x86_64",
+        WORKFLOW_MANAGER_INSTALL_SKIP_SHELL_SETUP: "1",
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain(`Add ${installDir} to PATH to run \`wfm\` from any shell.`);
+      expect(fs.existsSync(path.join(homeDir, ".bashrc"))).toBe(false);
+    } finally {
+      await server.stop(true);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- make the curl installer update supported shell profiles automatically when the install directory is not already on `PATH`
- print an immediate shell reload command and keep a manual opt-out via `WORKFLOW_MANAGER_INSTALL_SKIP_SHELL_SETUP=1`
- add installer regression coverage and document the current-shell/new-shell behavior in the README and install guides

## Validation
- bun test tests/installer.test.ts
- bun run lint
- manual isolated-shell reproduction showing the old failure mode and the new-shell success path after profile setup

## Why
The release installer could successfully download `wfm` but leave it unavailable in the user's terminal because `~/.local/bin` was not on `PATH`. This change makes the post-install experience work in the common shell setups and explains the remaining current-shell limitation.