### PR TITLE
fix: harden runner validation docs and skills

### DIFF
--- a/doc/guide/how-it-works.md
+++ b/doc/guide/how-it-works.md
@@ -1,15 +1,15 @@
 # How It Works
 
-`workflow-manager` turns a Markdown workflow definition into a deterministic run.
+`workflow-manager` turns a Markdown or JSON workflow definition into a deterministic run.
 
 ## Execution flow
 
-1. Parse Markdown frontmatter into a `WorkflowDefinition`.
+1. Parse Markdown frontmatter or JSON into a `WorkflowDefinition`.
 2. Validate schema-level constraints (keys, dependencies, adapters, validation modes).
 3. Initialize run state (`queued` -> `running`) and create a `StepRun` for each step.
 4. Execute steps in order, enforcing `dependsOn` before each step starts.
 5. Build an input envelope with global state, step context, and adapter init data.
-6. Execute the step (currently through the mock executor).
+6. Execute the step through the configured adapter (`mock`, `opencode`, `codex`, or `claude-code`).
 7. Apply validation and confirmation policy.
 8. Resolve routing actions (`RETRY_CURRENT`, `ROLLBACK_PREVIOUS`, `RESTART_ALL`, or proceed).
 9. Record run and step events in sequence.

--- a/doc/guide/workflow-schema.md
+++ b/doc/guide/workflow-schema.md
@@ -50,7 +50,37 @@ JSON:
 - `inputSchema`: optional JSON schema-like shape for inputs
 - `outputSchema`: optional JSON schema-like shape for outputs
 - `defaultRetryPolicy.maxAttempts`: fallback retry attempts for steps
+- `skills`: optional map of portable skill definitions keyed by skill name
 - `steps` (required): ordered list of step definitions
+
+## Skill fields
+
+Top-level `skills` entries let workflows declare the skill markdown needed by adapter steps.
+
+```json
+{
+  "skills": {
+    "demo": {
+      "source": "./skills/demo/SKILL.md",
+      "content": "# Demo\n\nUse this guidance.",
+      "contentSha256": "64-char lowercase hex SHA-256",
+      "upstream": {
+        "repo": "github.com/acme/skills",
+        "ref": "main",
+        "path": "demo/SKILL.md"
+      }
+    }
+  }
+}
+```
+
+- `source`: optional local authoring path under `./skills/**/SKILL.md`
+- `content`: optional embedded skill markdown
+- `contentSha256`: optional integrity hash for embedded `content`
+- `upstream.repo`, `upstream.ref`, `upstream.path`: optional audit metadata
+- each skill must define `content` or `source`
+- `workflow-manager publish` embeds local skill content and writes `contentSha256`
+- pulled workflows must include embedded skill content for declared skills
 
 ## Step fields
 
@@ -77,3 +107,8 @@ JSON:
 - `kind` must be one of `task`, `approval`, `system`
 - adapter key must be one of the supported adapters
 - validation mode must be `none`, `human`, or `external`
+- skill names must contain only letters, numbers, `_`, `.`, and `-`
+- skill `source` paths must stay under `./skills/**/SKILL.md`
+- skill `contentSha256` must be a lowercase 64-character SHA-256 and match embedded `content`
+- list fields such as `objectives`, `dependsOn`, `taskSpec.init.skills`, `taskSpec.init.mcps`, and `taskSpec.init.systemPrompts` must contain strings
+- retry `maxAttempts` values must be positive integers

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,6 +1,6 @@
 # workflow-manager
 
-`workflow-manager` is a CLI for defining and executing workflows from Markdown frontmatter.
+`workflow-manager` is a CLI for defining and executing workflows from Markdown frontmatter or JSON files.
 
 ```bash
 npm install -g @workflow-manager/runner
@@ -20,7 +20,7 @@ It is designed for agentic and human-in-the-loop execution where each step can h
 
 ## Highlights
 
-- Markdown-native workflow definitions
+- Markdown and JSON workflow definitions
 - Deterministic in-memory execution engine
 - Event timeline output for auditability
 - Validation support (`none`, `human`, `external`)

--- a/skills/workflow-manager-cli/SKILL.md
+++ b/skills/workflow-manager-cli/SKILL.md
@@ -55,6 +55,8 @@ wfm validate ./example-workflow.json
 
 wfm run ./example-workflow.md --confirm discover,qa_gate:human
 wfm run ./example-workflow.json --auto-confirm-all
+wfm run ./example-workflow.json --auto-confirm-all --verbose
+wfm run ./example-workflow.json --auto-confirm-all --json
 ```
 
 ## Remote registry commands
@@ -77,7 +79,8 @@ wfm pull alice/remote-bunny --output ./remote-bunny.json
 - Use Markdown workflows when the user wants editable frontmatter plus notes
 - Use JSON workflows when the user wants machine-generated or strongly structured files
 - Use `--auto-confirm-all` only when the workflow is intentionally non-interactive
-- When publishing, preserve the source format the user authored
+- When publishing workflows with declared local skills, expect the CLI to bundle skill markdown into a JSON artifact with `contentSha256`
+- When publishing workflows without declared skills, preserve the source format the user authored
 
 ## Workflow authoring checklist
 
@@ -86,6 +89,7 @@ wfm pull alice/remote-bunny --output ./remote-bunny.json
 - Add `dependsOn` relationships explicitly
 - Set validation mode per step (`none`, `human`, `external`)
 - Configure adapter initialization under `taskSpec.init`
+- Declare portable skills at top-level `skills` when a workflow step references local skill markdown
 - Use stable step keys because tests and docs may refer to them
 
 ## Adapter and validation notes
@@ -93,6 +97,7 @@ wfm pull alice/remote-bunny --output ./remote-bunny.json
 - Supported adapters include `mock`, `opencode`, `codex`, and `claude-code`
 - Human approvals should stay explicit in workflow definitions
 - External validation should be deterministic where possible
+- Skill sources must stay under `./skills/**/SKILL.md`; publishing embeds their markdown into `skills[*].content`
 - Use the mock adapter for fast tests and scaffolding flows
 
 ## Recommended project references

--- a/src/index.ts
+++ b/src/index.ts
@@ -455,11 +455,17 @@ async function cmdRun(filePath: string): Promise<number> {
     const inputRaw = getFlag("--input");
     let input: Record<string, unknown> = {};
     if (inputRaw) {
-      const parsed: unknown = inputRaw.trimStart().startsWith("{")
-        ? JSON.parse(inputRaw.replace(/[\n\r]/g, " "))
-        : JSON.parse(fs.readFileSync(path.resolve(inputRaw), "utf-8"));
+      let parsed: unknown;
+      try {
+        parsed = inputRaw.trimStart().startsWith("{")
+          ? JSON.parse(inputRaw.replace(/[\n\r]/g, " "))
+          : JSON.parse(fs.readFileSync(path.resolve(inputRaw), "utf-8"));
+      } catch (error) {
+        console.error(`--input must be a JSON object or path to a JSON object: ${(error as Error).message}`);
+        return 1;
+      }
       if (typeof parsed !== "object" || Array.isArray(parsed) || parsed === null) {
-        console.error("--input must be a JSON object");
+        console.error("--input must be a JSON object or path to a JSON object");
         return 1;
       }
       input = parsed as Record<string, unknown>;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2,9 +2,11 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import matter from "gray-matter";
-import type { AdapterKey, SkillEntry, WorkflowDefinition } from "./types.js";
+import type { AdapterKey, SkillEntry, StepDefinition, ValidationMode, WorkflowDefinition } from "./types.js";
 
 const SUPPORTED_ADAPTERS: AdapterKey[] = ["mock", "opencode", "codex", "claude-code"];
+const SUPPORTED_STEP_KINDS = ["task", "approval", "system"];
+const SUPPORTED_VALIDATION_MODES: ValidationMode[] = ["none", "human", "external"];
 const SKILL_NAME_PATTERN = /^[a-zA-Z0-9_.-]+$/;
 
 function hashContentSha256(content: string): string {
@@ -23,37 +25,132 @@ function isAllowedLocalSkillSourcePath(source: string): boolean {
   return withoutDot.endsWith("/SKILL.md");
 }
 
-function validateSkillEntry(name: string, entry: SkillEntry, errors: string[]): void {
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function hasNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function validateStringArray(value: unknown, label: string, errors: string[]): value is string[] {
+  if (value === undefined) {
+    return true;
+  }
+
+  if (!isStringArray(value)) {
+    errors.push(`${label} must be an array of strings`);
+    return false;
+  }
+
+  return true;
+}
+
+function validateValidationSpec(value: unknown, label: string, errors: string[]): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (!isPlainObject(value)) {
+    errors.push(`${label} must be an object`);
+    return;
+  }
+
+  const mode = value.mode;
+  if (mode !== undefined && (typeof mode !== "string" || !SUPPORTED_VALIDATION_MODES.includes(mode as ValidationMode))) {
+    errors.push(`${label}.mode must be one of ${SUPPORTED_VALIDATION_MODES.join(", ")}`);
+  }
+
+  for (const key of ["required", "autoConfirm"]) {
+    if (value[key] !== undefined && typeof value[key] !== "boolean") {
+      errors.push(`${label}.${key} must be a boolean`);
+    }
+  }
+
+  if (value.confirmerPolicy !== undefined && !hasNonEmptyString(value.confirmerPolicy)) {
+    errors.push(`${label}.confirmerPolicy must be a non-empty string when present`);
+  }
+}
+
+function validateRetryPolicy(value: unknown, label: string, errors: string[]): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (!isPlainObject(value)) {
+    errors.push(`${label} must be an object`);
+    return;
+  }
+
+  if (value.maxAttempts !== undefined) {
+    if (!Number.isInteger(value.maxAttempts) || Number(value.maxAttempts) < 1) {
+      errors.push(`${label}.maxAttempts must be a positive integer`);
+    }
+  }
+}
+
+function validateSkillEntry(name: string, entry: unknown, errors: string[]): void {
   if (!isSafeSkillName(name)) {
     errors.push(`Invalid skill name: ${name}`);
   }
 
-  if (!entry.content?.trim() && !entry.source?.trim()) {
+  if (!isPlainObject(entry)) {
+    errors.push(`Skill "${name}" must be an object`);
+    return;
+  }
+
+  const skill = entry as SkillEntry;
+  const content = typeof skill.content === "string" ? skill.content : undefined;
+  const source = typeof skill.source === "string" ? skill.source : undefined;
+  const contentSha256 = typeof skill.contentSha256 === "string" ? skill.contentSha256 : undefined;
+
+  if (skill.content !== undefined && typeof skill.content !== "string") {
+    errors.push(`Skill "${name}" content must be a string when present`);
+  }
+
+  if (skill.source !== undefined && typeof skill.source !== "string") {
+    errors.push(`Skill "${name}" source must be a string when present`);
+  }
+
+  if (!content?.trim() && !source?.trim()) {
     errors.push(`Skill "${name}" must define content or source`);
   }
 
-  if (entry.source && !isAllowedLocalSkillSourcePath(entry.source)) {
+  if (source && !isAllowedLocalSkillSourcePath(source)) {
     errors.push(`Skill "${name}" source must be under ./skills/**/SKILL.md`);
   }
 
-  if (entry.contentSha256) {
-    if (!/^[a-f0-9]{64}$/.test(entry.contentSha256)) {
+  if (skill.contentSha256 !== undefined && typeof skill.contentSha256 !== "string") {
+    errors.push(`Skill "${name}" contentSha256 must be a string when present`);
+  }
+
+  if (contentSha256) {
+    if (!/^[a-f0-9]{64}$/.test(contentSha256)) {
       errors.push(`Skill "${name}" contentSha256 must be a 64-char lowercase hex SHA-256`);
-    } else if (!entry.content?.trim()) {
+    } else if (!content?.trim()) {
       errors.push(`Skill "${name}" defines contentSha256 but has no content`);
-    } else if (hashContentSha256(entry.content) !== entry.contentSha256) {
+    } else if (hashContentSha256(content) !== contentSha256) {
       errors.push(`Skill "${name}" contentSha256 does not match content`);
     }
   }
 
-  if (entry.upstream) {
-    if (entry.upstream.repo !== undefined && (!entry.upstream.repo || typeof entry.upstream.repo !== "string")) {
+  if (skill.upstream !== undefined) {
+    if (!isPlainObject(skill.upstream)) {
+      errors.push(`Skill "${name}" upstream must be an object when present`);
+      return;
+    }
+
+    if (skill.upstream.repo !== undefined && !hasNonEmptyString(skill.upstream.repo)) {
       errors.push(`Skill "${name}" upstream.repo must be a non-empty string when present`);
     }
-    if (entry.upstream.ref !== undefined && (!entry.upstream.ref || typeof entry.upstream.ref !== "string")) {
+    if (skill.upstream.ref !== undefined && !hasNonEmptyString(skill.upstream.ref)) {
       errors.push(`Skill "${name}" upstream.ref must be a non-empty string when present`);
     }
-    if (entry.upstream.path !== undefined && (!entry.upstream.path || typeof entry.upstream.path !== "string")) {
+    if (skill.upstream.path !== undefined && !hasNonEmptyString(skill.upstream.path)) {
       errors.push(`Skill "${name}" upstream.path must be a non-empty string when present`);
     }
   }
@@ -123,26 +220,50 @@ export function parseWorkflowFile(filePath: string): WorkflowDefinition {
 export function validateWorkflow(def: WorkflowDefinition): string[] {
   const errors: string[] = [];
   const seen = new Set<string>();
+  const workflow = def as Partial<WorkflowDefinition>;
 
-  if (!def.key.trim()) {
+  if (!hasNonEmptyString(workflow.key)) {
     errors.push("Workflow key is required");
   }
 
-  if (!def.title.trim()) {
+  if (!hasNonEmptyString(workflow.title)) {
     errors.push("Workflow title is required");
   }
 
-  if (!Array.isArray(def.steps) || def.steps.length === 0) {
+  if (workflow.objectives !== undefined && !isStringArray(workflow.objectives)) {
+    errors.push("Workflow objectives must be an array of strings");
+  }
+
+  validateRetryPolicy(workflow.defaultRetryPolicy, "defaultRetryPolicy", errors);
+
+  if (workflow.skills !== undefined) {
+    if (!isPlainObject(workflow.skills)) {
+      errors.push("Workflow skills must be an object");
+    } else {
+      for (const [name, entry] of Object.entries(workflow.skills)) {
+        validateSkillEntry(name, entry, errors);
+      }
+    }
+  }
+
+  if (!Array.isArray(workflow.steps) || workflow.steps.length === 0) {
     errors.push("Workflow must define at least one step");
     return errors;
   }
 
-  for (const [name, entry] of Object.entries(def.skills ?? {})) {
-    validateSkillEntry(name, entry, errors);
-  }
+  const stepKeys = new Set(
+    workflow.steps
+      .filter((step): step is StepDefinition => isPlainObject(step) && hasNonEmptyString(step.key))
+      .map((step) => step.key)
+  );
 
-  for (const step of def.steps) {
-    if (!step.key || !step.key.trim()) {
+  for (const step of workflow.steps) {
+    if (!isPlainObject(step)) {
+      errors.push("Each step must be an object");
+      continue;
+    }
+
+    if (!hasNonEmptyString(step.key)) {
       errors.push("Each step must define a non-empty key");
       continue;
     }
@@ -150,33 +271,70 @@ export function validateWorkflow(def: WorkflowDefinition): string[] {
     if (seen.has(step.key)) errors.push(`Duplicate step key: ${step.key}`);
     seen.add(step.key);
 
-    if (!["task", "approval", "system"].includes(step.kind)) {
+    if (typeof step.kind !== "string" || !SUPPORTED_STEP_KINDS.includes(step.kind)) {
       errors.push(`Invalid step kind for ${step.key}: ${step.kind}`);
     }
 
     if (step.kind === "task" && !step.taskSpec) {
       errors.push(`Task step ${step.key} is missing taskSpec`);
+    } else if (step.taskSpec !== undefined && !isPlainObject(step.taskSpec)) {
+      errors.push(`Task spec for ${step.key} must be an object`);
     }
 
     if (step.kind === "approval" && !step.approvalSpec) {
       errors.push(`Approval step ${step.key} is missing approvalSpec`);
+    } else if (step.approvalSpec !== undefined && !isPlainObject(step.approvalSpec)) {
+      errors.push(`Approval spec for ${step.key} must be an object`);
     }
 
-    for (const dep of step.dependsOn ?? []) {
-      if (!def.steps.some((s) => s.key === dep)) {
-        errors.push(`Step ${step.key} depends on unknown step ${dep}`);
+    validateRetryPolicy(step.retryPolicy, `Retry policy for ${step.key}`, errors);
+    validateValidationSpec(step.validation, `Validation for ${step.key}`, errors);
+
+    if (step.dependsOn !== undefined && !isStringArray(step.dependsOn)) {
+      errors.push(`Step ${step.key} dependsOn must be an array of strings`);
+    } else {
+      for (const dep of step.dependsOn ?? []) {
+        if (!stepKeys.has(dep)) {
+          errors.push(`Step ${step.key} depends on unknown step ${dep}`);
+        }
       }
     }
 
-    const adapter = step.taskSpec?.adapterKey;
-    if (adapter && !SUPPORTED_ADAPTERS.includes(adapter)) {
+    const taskSpec = isPlainObject(step.taskSpec) ? step.taskSpec : undefined;
+    const adapter = taskSpec?.adapterKey;
+    if (adapter !== undefined && (typeof adapter !== "string" || !SUPPORTED_ADAPTERS.includes(adapter as AdapterKey))) {
       errors.push(`Unsupported adapter for ${step.key}: ${adapter}`);
     }
 
-    const mode = step.validation?.mode ?? step.approvalSpec?.validation?.mode;
-    if (mode && !["none", "human", "external"].includes(mode)) {
-      errors.push(`Invalid validation mode for ${step.key}: ${mode}`);
+    if (taskSpec?.capabilityRequirements !== undefined) {
+      validateStringArray(taskSpec.capabilityRequirements, `Capability requirements for ${step.key}`, errors);
     }
+
+    if (taskSpec?.init !== undefined) {
+      if (!isPlainObject(taskSpec.init)) {
+        errors.push(`Task init for ${step.key} must be an object`);
+      } else {
+        validateStringArray(taskSpec.init.skills, `Task init skills for ${step.key}`, errors);
+        validateStringArray(taskSpec.init.mcps, `Task init mcps for ${step.key}`, errors);
+        validateStringArray(taskSpec.init.systemPrompts, `Task init systemPrompts for ${step.key}`, errors);
+        if (taskSpec.init.model !== undefined && !hasNonEmptyString(taskSpec.init.model)) {
+          errors.push(`Task init model for ${step.key} must be a non-empty string when present`);
+        }
+      }
+    }
+
+    if (taskSpec?.payload !== undefined && !isPlainObject(taskSpec.payload)) {
+      errors.push(`Task payload for ${step.key} must be an object`);
+    }
+
+    const approvalSpec = isPlainObject(step.approvalSpec) ? step.approvalSpec : undefined;
+    if (approvalSpec?.autoApprove !== undefined && typeof approvalSpec.autoApprove !== "boolean") {
+      errors.push(`Approval autoApprove for ${step.key} must be a boolean`);
+    }
+    if (approvalSpec?.approverPolicy !== undefined && !hasNonEmptyString(approvalSpec.approverPolicy)) {
+      errors.push(`Approval approverPolicy for ${step.key} must be a non-empty string when present`);
+    }
+    validateValidationSpec(approvalSpec?.validation, `Approval validation for ${step.key}`, errors);
   }
 
   return errors;

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -211,4 +211,62 @@ describe("parser — skills validation", () => {
     } as ReturnType<typeof parseWorkflowJson>;
     expect(validateWorkflow(wf)).toEqual([]);
   });
+
+  it("reports validation errors instead of throwing for malformed runtime shapes", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wm-parser-"));
+    const file = path.join(dir, "malformed.json");
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        key: 123,
+        title: [],
+        objectives: "ship it",
+        defaultRetryPolicy: { maxAttempts: 0 },
+        skills: {
+          demo: {
+            content: 42,
+            source: "../demo/SKILL.md",
+            contentSha256: 123,
+            upstream: { repo: "" },
+          },
+        },
+        steps: [
+          {
+            key: "plan",
+            kind: "task",
+            dependsOn: "missing",
+            retryPolicy: { maxAttempts: 0 },
+            validation: { mode: "bad", required: "yes" },
+            taskSpec: {
+              adapterKey: "bad-adapter",
+              capabilityRequirements: [1],
+              init: {
+                skills: "demo",
+                mcps: [1],
+                systemPrompts: "prompt",
+                model: "",
+              },
+              payload: [],
+            },
+          },
+          "not-a-step",
+        ],
+      }),
+      "utf-8"
+    );
+
+    const wf = parseWorkflowJson(file);
+    expect(() => validateWorkflow(wf)).not.toThrow();
+    const errors = validateWorkflow(wf);
+    expect(errors).toContain("Workflow key is required");
+    expect(errors).toContain("Workflow title is required");
+    expect(errors).toContain("Workflow objectives must be an array of strings");
+    expect(errors).toContain("defaultRetryPolicy.maxAttempts must be a positive integer");
+    expect(errors).toContain('Skill "demo" content must be a string when present');
+    expect(errors).toContain('Skill "demo" source must be under ./skills/**/SKILL.md');
+    expect(errors).toContain("Step plan dependsOn must be an array of strings");
+    expect(errors).toContain("Unsupported adapter for plan: bad-adapter");
+    expect(errors).toContain("Task init skills for plan must be an array of strings");
+    expect(errors).toContain("Each step must define a non-empty key");
+  });
 });

--- a/tests/runnerCli.test.ts
+++ b/tests/runnerCli.test.ts
@@ -430,6 +430,16 @@ describe("CliRunRenderer prompt handling", () => {
     });
   }, 15000);
 
+  it("fails clearly when --input is not a JSON object", async () => {
+    await runCliTestExclusive(async () => {
+      const workflowPath = writeWorkflow();
+      const result = await runCommand(["run", workflowPath, "--input", "[1]"]);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("--input must be a JSON object or path to a JSON object");
+    });
+  });
+
   it("approves a waiting run via the CLI control command", async () => {
     await runCliTestExclusive(async () => {
       const workflowPath = writeApprovalWorkflow();


### PR DESCRIPTION
## Summary
- harden workflow validation for malformed runtime field shapes, skill metadata, retry policy, and adapter init arrays
- improve CLI --input errors for non-object or invalid JSON input
- align docs and bundled skill guidance with JSON workflows, real adapters, and skill bundling behavior

## Validation
- bun test tests/parser.test.ts tests/skillResolver.test.ts tests/publish-bundle.test.ts tests/runnerCli.test.ts
- bun run build
- bunx biome lint src/parser.ts src/index.ts tests/parser.test.ts tests/runnerCli.test.ts doc/index.md doc/guide/how-it-works.md doc/guide/workflow-schema.md skills/workflow-manager-cli/SKILL.md --error-on-warnings

Note: full bun run lint is currently blocked by the pre-existing untracked .claude/ worktree containing a nested biome.json.