### PR TITLE
fix: address open runner and registry bugs

### DIFF
--- a/apps/remote-registry/src/lib/remoteApi.ts
+++ b/apps/remote-registry/src/lib/remoteApi.ts
@@ -12,6 +12,31 @@ import type {
 } from "../types";
 import type { WorkflowDefinitionInput } from "./workflowSource";
 
+function objectPayload(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function httpStatusMessage(response: Response): string {
+  return `HTTP ${response.status}${response.statusText ? ` ${response.statusText}` : ""}`;
+}
+
+async function readFunctionPayload(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text.trim()) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    if (!response.ok) {
+      const body = text.trim().slice(0, 500);
+      throw new Error(body ? `${httpStatusMessage(response)}: ${body}` : httpStatusMessage(response));
+    }
+    throw new Error("Unexpected non-JSON response from server");
+  }
+}
+
 async function callFunction<T>(path: string, init: RequestInit = {}): Promise<T> {
   const response = await fetch(`${getSupabaseUrl()}/functions/v1/${path}`, {
     ...init,
@@ -22,9 +47,15 @@ async function callFunction<T>(path: string, init: RequestInit = {}): Promise<T>
     },
   });
 
-  const payload = (await response.json()) as Record<string, unknown>;
+  const payload = await readFunctionPayload(response);
   if (!response.ok) {
-    const message = typeof payload.error === "string" ? payload.error : typeof payload.message === "string" ? payload.message : "Remote request failed";
+    const errorPayload = objectPayload(payload);
+    const message =
+      typeof errorPayload.error === "string"
+        ? errorPayload.error
+        : typeof errorPayload.message === "string"
+          ? errorPayload.message
+          : httpStatusMessage(response);
     throw new Error(message);
   }
 

--- a/apps/remote-registry/src/pages/DashboardPage.tsx
+++ b/apps/remote-registry/src/pages/DashboardPage.tsx
@@ -45,7 +45,7 @@ export function DashboardPage() {
   const stats = useMemo(() => {
     const items = analytics.data?.items ?? [];
     const totalDownloads = items.reduce((sum, item) => sum + item.totalDownloads, 0);
-    const lastPublishedAt = items
+    const lastDownloadedAt = items
       .map((item) => item.lastDownloadedAt)
       .filter((value): value is string => Boolean(value))
       .sort()
@@ -62,7 +62,7 @@ export function DashboardPage() {
     return {
       count: items.length,
       totalDownloads,
-      lastPublishedAt,
+      lastDownloadedAt,
       lastSevenDayDownloads,
       activeCount: items.filter((item) => item.lastDownloadedAt).length,
       latestDraftCount: items.filter((item) => latestAnalyticsVersion(item)?.publishedState === "draft").length,
@@ -157,7 +157,7 @@ export function DashboardPage() {
           <div className="kpi__card">
             <span className="kpi__label">Last activity</span>
             <span className="kpi__value">
-              {stats.lastPublishedAt ? new Date(stats.lastPublishedAt).toLocaleDateString() : "—"}
+              {stats.lastDownloadedAt ? new Date(stats.lastDownloadedAt).toLocaleDateString() : "—"}
             </span>
             <span className="kpi__hint">most recent pull</span>
           </div>

--- a/apps/remote-registry/src/pages/PublishWorkflowPage.tsx
+++ b/apps/remote-registry/src/pages/PublishWorkflowPage.tsx
@@ -4,7 +4,7 @@ import { Link, useParams } from "react-router-dom";
 import { FileCode2, Rocket, Sparkles } from "lucide-react";
 import { useAuth } from "../auth/useAuth";
 import { publishedWorkflowDetailPath } from "../lib/workflowPublishing";
-import { fetchManagedWorkflow, publishWorkflow } from "../lib/remoteApi";
+import { fetchManagedWorkflow, fetchWhoAmI, publishWorkflow } from "../lib/remoteApi";
 import { parseWorkflowSource } from "../lib/workflowSource";
 import type { ManagedWorkflow } from "../types";
 import { Button } from "../ui/Button";
@@ -53,6 +53,7 @@ interface PublishWorkflowFormProps {
   accessToken: string;
   managedSlug?: string;
   initialState: PublishFormState;
+  ownerHandle?: string;
 }
 
 function defaultPublishFormState(): PublishFormState {
@@ -80,7 +81,7 @@ function managedPublishFormState(workflow: ManagedWorkflow): PublishFormState {
   };
 }
 
-function PublishWorkflowForm({ accessToken, managedSlug, initialState }: PublishWorkflowFormProps) {
+function PublishWorkflowForm({ accessToken, managedSlug, initialState, ownerHandle }: PublishWorkflowFormProps) {
   const queryClient = useQueryClient();
   const [rawSource, setRawSource] = useState(initialState.rawSource);
   const [description, setDescription] = useState(initialState.description);
@@ -126,6 +127,8 @@ function PublishWorkflowForm({ accessToken, managedSlug, initialState }: Publish
       setError((mutationError as Error).message);
     },
   });
+  const publishedWorkflowPath =
+    publishMutation.data && ownerHandle ? publishedWorkflowDetailPath(ownerHandle, publishMutation.data.slug) : null;
 
   return (
     <div className="stack-lg">
@@ -287,8 +290,12 @@ function PublishWorkflowForm({ accessToken, managedSlug, initialState }: Publish
         {publishMutation.data && (
           <StatusBanner tone="ok">
             Published <strong>{publishMutation.data.slug}</strong> as {publishMutation.data.version}.{" "}
-            <Link to={publishedWorkflowDetailPath(publishMutation.data.ownerUserId, publishMutation.data.slug)}>View public page</Link>
-            {" · "}
+            {publishedWorkflowPath && (
+              <>
+                <Link to={publishedWorkflowPath}>View public page</Link>
+                {" · "}
+              </>
+            )}
             <Link to="/dashboard">Return to dashboard</Link>
           </StatusBanner>
         )}
@@ -316,6 +323,11 @@ function PublishWorkflowForm({ accessToken, managedSlug, initialState }: Publish
 export function PublishWorkflowPage() {
   const { session } = useAuth();
   const { slug: managedSlug } = useParams();
+  const profile = useQuery({
+    queryKey: ["profile", session?.access_token],
+    queryFn: () => fetchWhoAmI(session!.access_token),
+    enabled: Boolean(session?.access_token),
+  });
   const managedWorkflow = useQuery({
     queryKey: ["managed-workflow", session?.access_token, managedSlug],
     queryFn: () => fetchManagedWorkflow(session!.access_token, managedSlug!),
@@ -362,6 +374,7 @@ export function PublishWorkflowPage() {
       accessToken={session.access_token}
       managedSlug={managedSlug}
       initialState={initialState}
+      ownerHandle={profile.data?.username ?? profile.data?.userId}
     />
   );
 }

--- a/src/claudeCodeExecutor.ts
+++ b/src/claudeCodeExecutor.ts
@@ -117,8 +117,8 @@ export function executeClaudeCodeStep(
   input: InputEnvelope,
   attempt: number,
   workflow?: WorkflowDefinition,
-   workflowFilePath?: string,
-   hooks?: StepExecutionHooks
+  workflowFilePath?: string,
+  hooks?: StepExecutionHooks
 ): Promise<OutputEnvelope> {
   const startedAt = Date.now();
   const payload = asRecord(step.taskSpec?.payload);
@@ -131,7 +131,7 @@ export function executeClaudeCodeStep(
         ? payload.model
         : undefined;
 
-  const args: string[] = ["-p", prompt];
+  const args: string[] = ["-p"];
   if (configuredModel) {
     args.push("--model", configuredModel);
   }
@@ -158,6 +158,8 @@ export function executeClaudeCodeStep(
     }
 
     hooks?.onStarted?.({ command: "claude", args, model: configuredModel });
+    child.stdin?.on("error", () => undefined);
+    child.stdin?.end(prompt);
 
     const outChunks: string[] = [];
     const errChunks: string[] = [];

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -889,7 +889,8 @@ export async function runWorkflow(definition: WorkflowDefinition, options?: RunO
 
     if (output.execution_status === "QA_REJECTED") {
       const retryMax = step.retryPolicy?.maxAttempts ?? definition.defaultRetryPolicy?.maxAttempts ?? 1;
-      if (output.qa_routing.action === "RETRY_CURRENT") {
+      const qaAction = String(output.qa_routing.action);
+      if (qaAction === "RETRY_CURRENT") {
         if (stepRun.attempt < retryMax) {
           stepRun.status = "pending";
           touchStep(step.key, { finishedAt: new Date().toISOString() });
@@ -907,7 +908,7 @@ export async function runWorkflow(definition: WorkflowDefinition, options?: RunO
         break;
       }
 
-      if (output.qa_routing.action === "ROLLBACK_PREVIOUS") {
+      if (qaAction === "ROLLBACK_PREVIOUS") {
         if (index === 0) {
           stepRun.status = "failed";
           runStatus = "failed";
@@ -922,6 +923,7 @@ export async function runWorkflow(definition: WorkflowDefinition, options?: RunO
         const prevStep = orderedSteps[index - 1];
         const prevRun = stepRuns.get(prevStep.key)!;
         prevRun.status = "pending";
+        prevRun.attempt = 0;
         prevRun.confirmed = false;
         delete prevRun.output;
         delete globalState[prevStep.key];
@@ -937,7 +939,7 @@ export async function runWorkflow(definition: WorkflowDefinition, options?: RunO
         continue;
       }
 
-      if (output.qa_routing.action === "RESTART_ALL") {
+      if (qaAction === "RESTART_ALL") {
         for (const s of definition.steps) {
           const sr = stepRuns.get(s.key)!;
           sr.status = "pending";
@@ -953,6 +955,15 @@ export async function runWorkflow(definition: WorkflowDefinition, options?: RunO
         index = 0;
         continue;
       }
+
+      stepRun.status = "failed";
+      runStatus = "failed";
+      currentStepKey = step.key;
+      touchStep(step.key, { finishedAt: new Date().toISOString() });
+      touchRun(true);
+      pushEvent("run.failed", { stepKey: step.key, reason: `Unknown QA action: ${qaAction}` }, step.key);
+      emitSnapshot();
+      break;
     }
 
     stepRun.status = "succeeded";

--- a/src/runnerSession.ts
+++ b/src/runnerSession.ts
@@ -255,9 +255,6 @@ export class RunnerSessionStore implements RunObserver, RunController {
     this.snapshotState = cloneSnapshot(snapshot);
     this.stepDetailsState = cloneStepDetails(stepDetails);
     this.sessionState.run.status = snapshot.status;
-    if (!snapshot.waitingForApproval && this.pendingApproval) {
-      this.pendingApproval = null;
-    }
   }
 
   onLog(log: RunnerLogChunk): void {

--- a/tests/claudeCodeExecutor.test.ts
+++ b/tests/claudeCodeExecutor.test.ts
@@ -159,6 +159,19 @@ describe("executeClaudeCodeStep — prompt construction", () => {
     expect(result.mutated_payload.model).toBe("claude-opus-4-5");
   });
 
+  it("does not expose the prompt in claude process arguments", async () => {
+    let startedArgs: string[] = [];
+    const result = await executeClaudeCodeStep(baseStep({ prompt: "Sensitive workflow prompt" }), baseInput(), 1, undefined, undefined, {
+      onStarted(payload) {
+        startedArgs = Array.isArray(payload?.args) ? payload.args.map(String) : [];
+      },
+    });
+
+    expect(result.step_id).toBe("spec");
+    expect(startedArgs).toContain("-p");
+    expect(startedArgs).not.toContain("Sensitive workflow prompt");
+  });
+
   it("prefers init.model passed through priming_configuration", async () => {
     const input = baseInput();
     input.priming_configuration.model = "claude-sonnet-4";

--- a/tests/engine.test.ts
+++ b/tests/engine.test.ts
@@ -143,6 +143,52 @@ describe("engine routing", () => {
     expect(retried.length).toBeGreaterThan(0);
   });
 
+  it("resets previous step attempts when rolling back", async () => {
+    let first = 0;
+    let second = 0;
+    const wf: WorkflowDefinition = {
+      key: "rollback-attempt-wf",
+      title: "rollback-attempt-wf",
+      steps: [
+        {
+          key: "s1",
+          kind: "task",
+          validation: { mode: "none", required: false, autoConfirm: true },
+          retryPolicy: { maxAttempts: 2 },
+          taskSpec: {
+            adapterKey: "mock",
+            payload: {
+              get mockResult() {
+                first += 1;
+                return first === 2 ? "retry" : "success";
+              },
+            } as unknown as Record<string, unknown>,
+          },
+        },
+        {
+          key: "s2",
+          kind: "task",
+          dependsOn: ["s1"],
+          validation: { mode: "none", required: false, autoConfirm: true },
+          retryPolicy: { maxAttempts: 2 },
+          taskSpec: {
+            adapterKey: "mock",
+            payload: {
+              get mockResult() {
+                return second++ === 0 ? "rollback" : "success";
+              },
+            } as unknown as Record<string, unknown>,
+          },
+        },
+      ],
+    };
+
+    const result = await runWorkflow(wf, { autoConfirmAll: true });
+
+    expect(result.status).toBe("succeeded");
+    expect(result.stepRuns.find((step) => step.stepKey === "s1")?.attempt).toBe(2);
+  });
+
   it("runs dependencies before dependents even when declared later", async () => {
     const wf: WorkflowDefinition = {
       key: "dependency-order-wf",

--- a/tests/remote-registry-app.test.ts
+++ b/tests/remote-registry-app.test.ts
@@ -63,6 +63,12 @@ steps:
     expect(authorization).toBe("Bearer access-token");
   });
 
+  it("preserves HTTP context for non-JSON remote errors", async () => {
+    globalThis.fetch = (async () => new Response("Bad gateway", { status: 502, statusText: "Bad Gateway" })) as typeof fetch;
+
+    await expect(getWorkflow("alice", "demo")).rejects.toThrow("HTTP 502 Bad Gateway: Bad gateway");
+  });
+
   it("includes the session token and public publish payload when creating a workflow", async () => {
     let authorization = "";
     let body: Record<string, unknown> | null = null;
@@ -96,8 +102,8 @@ steps:
     expect(body?.slug).toBe("demo");
   });
 
-  it("builds a workflow detail path from the owner user id after publishing", () => {
-    expect(publishedWorkflowDetailPath("user-1", "demo-flow")).toBe("/workflow/user-1/demo-flow");
+  it("builds a workflow detail path from the owner handle after publishing", () => {
+    expect(publishedWorkflowDetailPath("alice", "demo-flow")).toBe("/workflow/alice/demo-flow");
   });
 
   it("prefers the newest analytics version for draft visibility messaging", () => {

--- a/tests/runnerApi.test.ts
+++ b/tests/runnerApi.test.ts
@@ -207,6 +207,18 @@ describe("runner API", () => {
     expect(store.stepDetail("plan")?.adapter).toBe("pi-agent");
   });
 
+  it("keeps pending approvals until they are explicitly resolved", async () => {
+    const runId = "run-approval-lifetime";
+    const workflow = approvalWorkflow();
+    const store = new RunnerSessionStore({ runId, workflow, objective: workflow.title, objectives: [] });
+    const pending = store.waitForDecision({ stepKey: "review", reason: "needs approval", validation: "human" });
+    const snapshot = store.snapshot();
+    store.onSnapshot({ ...snapshot, waitingForApproval: null }, []);
+
+    expect(store.approve("review")).toEqual({ ok: true, stepKey: "review" });
+    await expect(pending).resolves.toEqual({ decision: "approved" });
+  });
+
   it("serves authenticated snapshots, details, and SSE events while a run is active", async () => {
     const workflow = workflowWithDelay();
     const runId = "run-api-test";


### PR DESCRIPTION
## Summary
- fixes runner QA rejection routing so unknown actions fail and rollback resets previous attempts
- keeps pending approvals alive until explicitly resolved and avoids exposing Claude prompts in process arguments
- hardens remote registry API error parsing and fixes dashboard/publish owner/date semantics

## Issues
Fixes #49
Fixes #50
Fixes #51
Fixes #52
Fixes #53
Fixes #54
Fixes #55

Reviewed #30, #31, #32, #33, and #34 as valid broader enhancement requests; they are not bundled into this bugfix PR.

## Validation
- bun run test:unit
- bun test tests/engine.test.ts tests/runnerApi.test.ts tests/claudeCodeExecutor.test.ts tests/remote-registry-app.test.ts
- bun run lint
- bun --cwd apps/remote-registry test:app
- bun --cwd apps/remote-registry lint
- bun --cwd apps/remote-registry build
- bun run build