### PR TITLE
fix runner edge cases

### DIFF
--- a/src/claudeCodeExecutor.ts
+++ b/src/claudeCodeExecutor.ts
@@ -117,8 +117,8 @@ export function executeClaudeCodeStep(
   input: InputEnvelope,
   attempt: number,
   workflow?: WorkflowDefinition,
-   workflowFilePath?: string,
-   hooks?: StepExecutionHooks
+  workflowFilePath?: string,
+  hooks?: StepExecutionHooks
 ): Promise<OutputEnvelope> {
   const startedAt = Date.now();
   const payload = asRecord(step.taskSpec?.payload);
@@ -131,7 +131,7 @@ export function executeClaudeCodeStep(
         ? payload.model
         : undefined;
 
-  const args: string[] = ["-p", prompt];
+  const args: string[] = ["-p", "--input-format", "text"];
   if (configuredModel) {
     args.push("--model", configuredModel);
   }
@@ -157,10 +157,16 @@ export function executeClaudeCodeStep(
       return;
     }
 
-    hooks?.onStarted?.({ command: "claude", args, model: configuredModel });
-
     const outChunks: string[] = [];
     const errChunks: string[] = [];
+    let timedOut = false;
+
+    hooks?.onStarted?.({ command: "claude", args, model: configuredModel, input: "stdin" });
+
+    child.stdin?.on("error", (err: Error) => {
+      errChunks.push(err.message);
+    });
+    child.stdin?.end(prompt);
 
     process.stderr.write(`\n─── step: ${step.key} (claude-code) ───\n`);
 
@@ -178,7 +184,6 @@ export function executeClaudeCodeStep(
       process.stderr.write(text);
     });
 
-    let timedOut = false;
     const timer = setTimeout(() => {
       timedOut = true;
       child.kill("SIGTERM");

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -543,6 +543,7 @@ export async function runWorkflow(definition: WorkflowDefinition, options?: RunO
         const prevStep = definition.steps[index - 1];
         const prevRun = stepRuns.get(prevStep.key)!;
         prevRun.status = "pending";
+        prevRun.attempt = 0;
         prevRun.confirmed = false;
         touchStep(prevStep.key, { startedAt: null, finishedAt: null, lastExecution: emptyExecution() });
         pushEvent("step.retried", { stepKey: prevStep.key, via: step.key }, prevStep.key);
@@ -569,6 +570,15 @@ export async function runWorkflow(definition: WorkflowDefinition, options?: RunO
         index = 0;
         continue;
       }
+
+      stepRun.status = "failed";
+      runStatus = "failed";
+      currentStepKey = step.key;
+      touchStep(step.key, { finishedAt: new Date().toISOString() });
+      touchRun(true);
+      pushEvent("run.failed", { stepKey: step.key, reason: `Unknown QA action: ${output.qa_routing.action}` }, step.key);
+      emitSnapshot();
+      break;
     }
 
     stepRun.status = "succeeded";

--- a/src/mockExecutor.ts
+++ b/src/mockExecutor.ts
@@ -157,6 +157,9 @@ export async function executeMockStep(
     case "restart":
       result = make("QA_REJECTED", "RESTART_ALL");
       break;
+    case "unknown-qa-action":
+      result = make("QA_REJECTED", "UNKNOWN_QA_ACTION" as QaAction);
+      break;
     case "yield":
       result = make("YIELD_EXTERNAL", "PROCEED");
       break;

--- a/src/runnerSession.ts
+++ b/src/runnerSession.ts
@@ -244,9 +244,6 @@ export class RunnerSessionStore implements RunObserver, RunController {
     this.snapshotState = cloneSnapshot(snapshot);
     this.stepDetailsState = cloneStepDetails(stepDetails);
     this.sessionState.run.status = snapshot.status;
-    if (!snapshot.waitingForApproval && this.pendingApproval) {
-      this.pendingApproval = null;
-    }
   }
 
   onLog(log: RunnerLogChunk): void {

--- a/tests/claudeCodeExecutor.test.ts
+++ b/tests/claudeCodeExecutor.test.ts
@@ -76,6 +76,21 @@ describe("executeClaudeCodeStep — output shape", () => {
     expect(result.mutated_payload.attempt).toBe(3);
   });
 
+  it("does not pass the prompt as a process argument", async () => {
+    const started: Record<string, unknown>[] = [];
+    const secretPrompt = "secret prompt that must stay out of argv";
+
+    await executeClaudeCodeStep(baseStep({ prompt: secretPrompt }), baseInput(), 1, undefined, undefined, {
+      onStarted: (payload) => started.push(payload ?? {}),
+    });
+
+    const args = started[0]?.args as string[];
+    expect(args).toContain("-p");
+    expect(args).toContain("--input-format");
+    expect(args.join(" ")).not.toContain(secretPrompt);
+    expect(started[0]?.input).toBe("stdin");
+  });
+
   it("handles invalid timeout without throwing", () => {
     expect(normalizeTimeout("not-a-number")).toBe(120000);
     expect(normalizeTimeout(-1)).toBe(120000);

--- a/tests/engine.test.ts
+++ b/tests/engine.test.ts
@@ -70,6 +70,71 @@ describe("engine routing", () => {
     expect(retried.length).toBeGreaterThan(0);
   });
 
+  it("fails QA_REJECTED steps with unknown QA routing actions", async () => {
+    const wf: WorkflowDefinition = {
+      key: "unknown-qa-action-wf",
+      title: "unknown-qa-action-wf",
+      steps: [
+        {
+          key: "s1",
+          kind: "task",
+          validation: { mode: "none", required: false, autoConfirm: true },
+          taskSpec: { adapterKey: "mock", payload: { mockResult: "unknown-qa-action" } },
+        },
+      ],
+    };
+
+    const result = await runWorkflow(wf, { autoConfirmAll: true });
+    expect(result.status).toBe("failed");
+    expect(result.stepRuns[0]?.status).toBe("failed");
+    expect(result.events.some((e) => e.type === "run.failed" && String(e.payload.reason).includes("Unknown QA action"))).toBe(true);
+  });
+
+  it("resets previous step attempts when rolling back", async () => {
+    let firstStep = 0;
+    let secondStep = 0;
+    const wf: WorkflowDefinition = {
+      key: "rollback-attempt-reset-wf",
+      title: "rollback-attempt-reset-wf",
+      defaultRetryPolicy: { maxAttempts: 2 },
+      steps: [
+        {
+          key: "s1",
+          kind: "task",
+          validation: { mode: "none", required: false, autoConfirm: true },
+          retryPolicy: { maxAttempts: 2 },
+          taskSpec: {
+            adapterKey: "mock",
+            payload: {
+              get mockResult() {
+                const outcomes = ["success", "retry", "success"];
+                return outcomes[firstStep++] ?? "success";
+              },
+            } as unknown as Record<string, unknown>,
+          },
+        },
+        {
+          key: "s2",
+          kind: "task",
+          dependsOn: ["s1"],
+          validation: { mode: "none", required: false, autoConfirm: true },
+          taskSpec: {
+            adapterKey: "mock",
+            payload: {
+              get mockResult() {
+                return secondStep++ === 0 ? "rollback" : "success";
+              },
+            } as unknown as Record<string, unknown>,
+          },
+        },
+      ],
+    };
+
+    const result = await runWorkflow(wf, { autoConfirmAll: true });
+    expect(result.status).toBe("succeeded");
+    expect(result.stepRuns.find((step) => step.stepKey === "s1")?.attempt).toBe(2);
+  });
+
   it("waits for confirmation when step requires human validation", async () => {
     const wf: WorkflowDefinition = {
       key: "confirm-wf",

--- a/tests/runnerApi.test.ts
+++ b/tests/runnerApi.test.ts
@@ -410,6 +410,23 @@ describe("runner API", () => {
     expect(result.status).toBe("succeeded");
   });
 
+  it("keeps pending approvals alive across snapshots without waiting state", async () => {
+    const workflow = approvalWorkflow();
+    const runId = "run-pending-survives-snapshot-test";
+    const store = new RunnerSessionStore({ runId, workflow, objective: workflow.title, objectives: [] });
+    const pending = store.waitForDecision({ stepKey: "review", reason: "manual review", validation: "human" });
+    const detail = store.stepDetail("review");
+    expect(detail).toBeDefined();
+
+    store.onSnapshot({ ...store.snapshot(), status: "running", waitingForApproval: null }, [detail!]);
+
+    const approval = store.approve("review", { actor: "tester" });
+    expect(approval.ok).toBe(true);
+    const decision = await pending;
+    expect(decision.decision).toBe("approved");
+    expect(decision.actor).toBe("tester");
+  });
+
   it("replays SSE events and paginates buffered logs", async () => {
     const workflow = workflowWithDelay(1);
     const runId = "run-replay-test";


### PR DESCRIPTION
## Summary
- Fail `QA_REJECTED` results that carry an unknown `qa_routing.action` instead of letting them fall through as success. Fixes #49.
- Keep runner approval promises alive until they are explicitly resolved, preventing local/remote attach clients from losing control of waiting runs. Fixes #50.
- Reset rolled-back step attempts and move Claude Code prompts to stdin so reruns behave correctly and prompts stay out of process arguments. Fixes #51 and fixes #52.

## Validation
- `bun run lint`
- `bun run test:unit`
- `bun run build`
- `bun run test:e2e`
- `bun run docs:build`
- `bun run remote-registry:build`
- `npm pack --dry-run`