### PR TITLE
docs(agents): enforce worktree, sync, and validation policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,9 +23,64 @@ It captures the repository-specific commands, constraints, and coding convention
 
 ## Branch And Worktree Expectations
 
-- Prefer a dedicated git worktree for non-trivial branch work and keep commands scoped to it.
+Agents MUST NOT make changes directly on `main` and MUST NOT reuse an unrelated existing branch.
+Before editing any file for a non-trivial task, perform the following sequence and confirm it succeeded:
+
+1. Confirm the task is non-trivial. Single-file typo, comment, or doc-only fixes (< ~5 lines) MAY skip worktree creation but still MUST run on a feature branch off the latest `main`.
+2. Ask the user (or infer from the task brief) for a short kebab-case branch slug, e.g. `fix-token-refresh`, `feat-publish-retry`, `docs-cli-flags`.
+3. Sync `main` first:
+   ```bash
+   git fetch origin --prune
+   git -C <main-checkout> checkout main
+   git -C <main-checkout> pull --ff-only origin main
+   ```
+4. Create a new worktree off the freshly synced `main` using the repo convention `~/Development/worktrees/workflow-manager/<MM-DD-YY>/<slug>`:
+   ```bash
+   DATE=$(date +%m-%d-%y)
+   SLUG=<slug>
+   BRANCH=workflow-manager/${DATE}/${SLUG}
+   WT=~/Development/worktrees/workflow-manager/${DATE}/${SLUG}
+   git worktree add -b "${BRANCH}" "${WT}" main
+   cd "${WT}" && bun install
+   ```
+5. Run ALL subsequent commands inside the new worktree path. Never `cd` back to the original checkout for edits.
+6. Before opening a PR (or whenever `main` has moved during the task) rebase onto the latest `origin/main`:
+   ```bash
+   git fetch origin
+   git rebase origin/main
+   ```
+   If rebase produces conflicts the agent cannot confidently resolve, stop and surface them to the user instead of forcing through.
+7. Never `git push --force` to `main`. Force-pushes to feature branches are allowed only with `--force-with-lease`.
+
+Additional rules:
+
 - Do not assume the working tree is clean, and never revert user-authored changes unless explicitly asked.
 - Do not commit generated binaries or `dist/` output unless explicitly requested.
+- Existing worktrees listed by `git worktree list` are owned by other branches; do not reuse them.
+
+## Required Validation Before Done
+
+A task is not "done" until all of the following pass inside the task's worktree, in this order:
+
+1. `bun run lint`
+2. `bun test` (or the narrowest relevant subset first, then full `bun test` before declaring done)
+3. `bun run build`
+
+If the change touches `apps/remote-registry/`, also run `bun run remote-registry:test && bun run remote-registry:build`.
+If the change touches `doc/` or any user-facing CLI/schema, also run `bun run docs:build`.
+
+If any of these scripts fail, fix the failure or stop and report it — never declare completion with a red script.
+Re-run lint + build at minimum after every rebase onto `main`.
+
+## Skills To Load Proactively
+
+When applicable, load these skills from `skills/` before producing final output:
+
+- `skills/repo-hygiene/SKILL.md` — for any code change (dead code, lint, file placement, comment policy).
+- `skills/doc-sync/SKILL.md` — whenever CLI flags, schema, public types, or user-facing behavior change.
+- `skills/commit-discipline/SKILL.md` — before staging commits or opening a PR.
+- `skills/spec-driven-development/SKILL.md` — for any task estimated > 30 minutes or with ambiguous scope.
+- `skills/workflow-manager-cli/SKILL.md` — when authoring, validating, or publishing workflow definitions.
 
 ## Install And Setup
 

--- a/skills/commit-discipline/SKILL.md
+++ b/skills/commit-discipline/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: commit-discipline
+description: >
+  Load this skill before staging commits or opening a pull request in
+  workflow-manager. Enforces Conventional Commits, focused diffs, a clean
+  rebase onto origin/main, and PR descriptions that link to the work.
+type: core
+applies_to:
+  - ".git/**"
+  - "**/*"
+---
+
+# Commit Discipline
+
+Use this skill at the moment you are about to `git add`, `git commit`, or `gh pr create`. It encodes how this repo expects commits and PRs to look so that history stays readable and release tooling (release-please, changelogs) keeps working.
+
+## When to use this skill
+
+Load it when you are about to:
+
+- Stage changes for commit.
+- Author a commit message.
+- Rebase onto `origin/main` before opening a PR.
+- Open or update a pull request.
+
+Skip it for purely exploratory commands that do not touch git state.
+
+## Conventional Commits
+
+This repo uses Conventional Commits. The release tooling (`release-please-config.json`) reads commit subjects to decide version bumps and changelog entries. Format:
+
+```
+<type>(<optional-scope>): <imperative summary>
+```
+
+Allowed `type` values:
+
+- `feat` — user-visible new functionality.
+- `fix` — user-visible bug fix.
+- `perf` — performance improvement with no behavior change.
+- `refactor` — internal restructuring, no behavior change, no new feature.
+- `docs` — documentation only.
+- `test` — tests only.
+- `build` — build system, packaging, dependencies.
+- `ci` — CI configuration only.
+- `chore` — repo plumbing that does not fit the above and has no user impact.
+- `revert` — reverts a previous commit; reference the reverted SHA.
+
+Rules:
+
+- Subject in the imperative mood, no trailing period, max 72 chars.
+- Use a scope when the change is localized (e.g., `feat(cli): ...`, `fix(parser): ...`, `feat(remote-registry): ...`).
+- Use `!` for breaking changes (e.g., `feat(cli)!: rename --token to --auth-token`) AND include a `BREAKING CHANGE:` footer explaining the migration.
+- Body (optional) explains _why_, not _what_; reference issues/PRs by number.
+
+## Commit hygiene
+
+- One logical change per commit. Do not bundle unrelated edits.
+- Never commit secrets, `.env*` files, real tokens, generated `dist/` output (unless explicitly requested), `node_modules/`, or local Supabase data.
+- Never amend or force-push commits that already exist on `main`. Force-push to feature branches is allowed only with `--force-with-lease`.
+- If pre-commit / pre-push hooks fail, fix the underlying issue. Do not bypass with `--no-verify` unless the user explicitly asks.
+
+## Before opening a PR
+
+Inside the feature worktree:
+
+```bash
+git fetch origin
+git rebase origin/main
+bun run lint
+bun test
+bun run build
+```
+
+Plus the conditional scripts from `repo-hygiene` / `doc-sync` when applicable.
+
+If the rebase produces conflicts you cannot confidently resolve, stop and surface them to the user instead of force-pushing through them.
+
+## PR description template
+
+Open PRs against `main` with a description that contains:
+
+1. **Summary** — 1–3 bullets describing the change in user-visible terms.
+2. **Why** — link to the issue, spec, or user request driving the change.
+3. **How** — short note on the approach; call out anything non-obvious.
+4. **Validation** — list the exact commands you ran and that they passed (lint, test, build, plus any conditional ones).
+5. **Docs** — link to the doc files updated, or state explicitly "no user-visible behavior changed".
+6. **Risk / rollout** — call out feature flags, migration steps, or follow-ups.
+
+Example title:
+
+```
+feat(cli): add `wfm pull --output` flag for redirecting fetched workflows
+```
+
+## Anti-patterns to refuse
+
+- Subjects like `update stuff`, `wip`, `fix things`, `address review`.
+- Squashing unrelated commits together to "clean up history" right before merge.
+- Pushing to `main` directly.
+- Opening a PR with failing CI and asking reviewers to "ignore the red".
+- Mixing a refactor and a behavior change in the same commit.
+
+## Definition of done
+
+- Every commit subject is a valid Conventional Commit.
+- Branch is rebased on the latest `origin/main`.
+- All required scripts (lint, test, build, plus conditional ones) passed locally.
+- PR description follows the template and links updated docs.

--- a/skills/doc-sync/SKILL.md
+++ b/skills/doc-sync/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: doc-sync
+description: >
+  Load this skill whenever a change affects user-visible behavior in
+  workflow-manager: CLI flags, command output, workflow schema, public
+  TypeScript types, adapters, the remote registry surface, or environment
+  variables. Ensures README, doc/, AGENTS.md, and in-CLI help stay in sync.
+type: core
+applies_to:
+  - "src/index.ts"
+  - "src/parser.ts"
+  - "src/engine.ts"
+  - "src/types.ts"
+  - "src/remote/**"
+  - "apps/remote-registry/**"
+  - "doc/**"
+  - "README.md"
+  - "AGENTS.md"
+---
+
+# Doc Sync
+
+Use this skill to keep documentation honest. In this repo, documentation is part of the product surface — the CLI is published, workflows are shared via the remote registry, and the docs site is built from `doc/`. Out-of-date docs are a bug.
+
+## When to use this skill
+
+Load it whenever the change does any of the following:
+
+- Adds, removes, or renames a CLI command, flag, or argument in `src/index.ts`.
+- Changes workflow schema, defaults, or validation rules in `src/parser.ts` or `src/types.ts`.
+- Changes engine semantics (approvals, retries, rollback, restart, snapshot shape) in `src/engine.ts`.
+- Adds or changes an adapter (`mock`, `opencode`, `codex`, `claude-code`, future adapters).
+- Changes remote registry behavior in `src/remote/**` or `apps/remote-registry/**`.
+- Introduces or renames an environment variable or required local service.
+- Bumps a public type or contract referenced by docs or other packages.
+
+If none of the above is true, this skill is not needed.
+
+## Required updates by change type
+
+| Change | Update |
+| --- | --- |
+| New / renamed CLI command or flag | Usage text in `src/index.ts`, `README.md` Quickstart and CLI section, the matching `doc/` page, and the man page source if behavior is reflected there. |
+| Workflow schema change | `README.md` schema section, the relevant page under `doc/guide/` or `doc/reference/`, plus the `workflow-manager-cli` skill checklist if authoring rules shift. |
+| Engine semantics change | The corresponding `doc/` engine page and any example workflows in `example-workflow.{md,json}` that no longer demonstrate the new behavior accurately. |
+| Adapter added or changed | List of supported adapters in `AGENTS.md`, `README.md`, and `doc/`. The `workflow-manager-cli` skill must also list it. |
+| Remote registry change | `apps/remote-registry/DESIGN.md` if UI/UX shifts, `README.md` remote section, `doc/` remote pages, and any onboarding snippets. |
+| New env var or required service | `README.md` setup section, `AGENTS.md` Install And Setup, and any `.env.example` files. Never commit real secrets. |
+
+## Workflow
+
+1. Diff your change and list every user-visible surface it touches.
+2. For each surface, open the matching doc file and update it in the same PR. Do not defer to a follow-up.
+3. Rebuild docs to catch broken links or examples:
+   ```bash
+   bun run docs:build
+   ```
+4. If you changed the remote-registry app, also run:
+   ```bash
+   bun run remote-registry:build
+   ```
+5. Re-read the README quickstart end-to-end and confirm the commands you ship still work as written.
+
+## Style rules
+
+- Match the existing tone of the surrounding doc. Do not introduce a new voice.
+- Prefer runnable examples over prose. Examples should match the actual current CLI output.
+- Keep command examples copy-pasteable. No invented flags or fictitious env vars.
+- When you remove or rename a flag, document the migration in the same section, not in a separate changelog-only entry.
+- Cross-link related docs sparingly and only when they meaningfully help the reader.
+
+## Anti-patterns to refuse
+
+- Updating code without updating docs "because the docs are out of date anyway".
+- Adding a doc page that is not linked from the docs nav or another page.
+- Copying README content into `doc/` instead of linking, creating two sources of truth.
+- Leaving `TODO: update docs` markers in a finished PR.
+
+## Definition of done
+
+- Every user-visible behavioral change is reflected in `README.md`, the relevant `doc/` pages, in-CLI `--help`, and `AGENTS.md` where applicable.
+- `bun run docs:build` passes.
+- Examples in updated docs were actually executed (or visually verified) against the new behavior.

--- a/skills/repo-hygiene/SKILL.md
+++ b/skills/repo-hygiene/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: repo-hygiene
+description: >
+  Load this skill on any code change in workflow-manager. It enforces the
+  "leave the repo cleaner than you found it" rules: no dead code, no orphan
+  files, no stray comments, no unrelated formatting churn, and validated
+  scripts before declaring done.
+type: core
+applies_to:
+  - "src/**"
+  - "apps/**"
+  - "tests/**"
+  - "scripts/**"
+---
+
+# Repo Hygiene
+
+Use this skill whenever you edit, add, or delete code in this repository. It encodes the cleanliness rules already implied by `AGENTS.md` and `biome.json`, made explicit so they are followed every time.
+
+## When to use this skill
+
+Load it for any change under `src/`, `apps/`, `tests/`, or `scripts/`. Skip only for pure docs work in `doc/` and pure markdown edits at the repo root (those load `doc-sync` instead).
+
+## Core rules
+
+1. Smallest viable change. Edit only what the task requires. Do not refactor unrelated code, do not reformat unrelated files, do not rename unrelated symbols.
+2. No dead code. Remove unused imports, unused exports, unused locals, unreachable branches, and obsolete helpers in the files you touch. Do not leave `TODO`/`FIXME` without an associated issue link or a short, dated reason.
+3. No stray comments. Per `AGENTS.md` code style, do not add explanatory comments unless the user explicitly asks for them. Keep existing comments only if they are still accurate; delete misleading ones.
+4. File placement matters. Source goes in `src/`. Tests go in `tests/`. Remote-registry UI code stays inside `apps/remote-registry/`. Scripts stay in `scripts/`. Do not create new top-level files unless the task explicitly calls for them.
+5. Import discipline. ESM only. Node built-ins use the `node:` prefix. In `src/`, local imports use `.js` extensions; in `tests/`, local imports use `.ts` paths. Keep value imports first, then `import type` imports.
+6. Strict typing. Prefer `unknown` over `any` for untrusted input and narrow it before use. Reuse shared types from `src/types.ts` instead of inventing parallel shapes. Keep payloads JSON-serializable where possible.
+7. Error handling. CLI-facing code exits with clear messages and non-zero codes for failure. Validation errors are returned as strings for ordinary user-input problems, not thrown. Executor flows return structured `OutputEnvelope` failures rather than ad hoc exceptions.
+8. No silent swallowing. Never `catch` and ignore. If an error is intentionally non-fatal, log it with enough context to debug.
+9. No secrets. Never log tokens, env values, or credentials. Never commit `.env*` files or any local Supabase keys.
+
+## Pre-completion checklist
+
+Before declaring a task done, run inside the worktree:
+
+```bash
+bun run lint
+bun test            # narrowest relevant subset first; then full suite
+bun run build
+```
+
+Plus, when applicable:
+
+```bash
+bun run remote-registry:test && bun run remote-registry:build   # apps/remote-registry/**
+bun run docs:build                                              # doc/** or user-facing CLI/schema
+```
+
+If any script fails, fix it or stop and report it. Do not declare completion with a red script.
+
+## Anti-patterns to refuse
+
+- Adding a new dependency without checking `package.json` first.
+- Introducing a new top-level config file when an existing one can be extended.
+- Reformatting whole files because the editor auto-formatted them.
+- Leaving commented-out code "in case we need it later" — git history is the archive.
+- Mixing an unrelated refactor into a feature PR.
+
+## Definition of clean
+
+A change is clean when:
+
+- The diff contains only lines required by the task.
+- `git status` shows no unintended new files.
+- `bun run lint`, `bun test`, and `bun run build` are all green.
+- A future reader can understand the change without an accompanying explanation message.


### PR DESCRIPTION
## Summary
- Replace the thin worktree note in `AGENTS.md` with a strict 7-step branch/worktree workflow: always branch off the latest `origin/main`, work in `~/Development/worktrees/workflow-manager/<MM-DD-YY>/<slug>`, rebase onto `origin/main` before opening a PR, never force-push to `main`.
- Add a `Required Validation Before Done` section that gates completion on `bun run lint`, `bun test`, and `bun run build` (plus conditional `remote-registry:test`/`remote-registry:build` and `docs:build`).
- Add a `Skills To Load Proactively` pointer to `skills/`.
- Add three new skills: `repo-hygiene`, `doc-sync`, `commit-discipline`.

## Why
Recent work showed agents editing on `main`, skipping `origin/main` sync, and landing changes without docs updates or consistent commit conventions. Encoding these as agent-readable rules + skills closes those gaps without relying on every contributor remembering them.

## How
- Edited `AGENTS.md` only — no source/runtime code changed.
- New skills live under `skills/<name>/SKILL.md` following the existing format used by `skills/spec-driven-development/` and `skills/workflow-manager-cli/`.
- `repo-hygiene` codifies smallest-diff, no-dead-code, strict typing, and the pre-completion script checklist.
- `doc-sync` ships a change-to-doc mapping table so README, `doc/`, in-CLI `--help`, and `AGENTS.md` stay aligned.
- `commit-discipline` formalizes Conventional Commits (aligned with `release-please-config.json`) and a PR description template.

## Validation
Ran inside the worktree on top of latest `origin/main`:

- `bun run lint` ✅
- `bun run build` ✅
- `bun test` ✅ (145 pass, 2 skipped — the skipped ones are the existing local Supabase smoke tests that require a running local stack)

Docs build and `remote-registry:build` were not required because no `doc/` files or `apps/remote-registry/` source were touched.

## Docs
Documentation **is** the change in this PR (`AGENTS.md` + new `skills/*/SKILL.md`). No other docs needed updating because no user-visible CLI/schema behavior changed.

## Risk / rollout
- Risk: very low — docs/policy only, no code paths exercised at runtime.
- Rollout: takes effect for agents the moment this lands on `main`. Existing in-flight branches are not affected.
- Follow-up (optional): align the existing `Change Checklist For Agents` section at the bottom of `AGENTS.md` with the new `Required Validation Before Done` block. Left untouched here to keep the diff focused.