### PR TITLE
feat: run tasks with pi-agent by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ If `wfm` is not available immediately in the same terminal, run the shell reload
 - `src/index.ts`: CLI commands (`questions`, `scaffold`, `validate`, `run`)
 - `src/parser.ts`: parsing + validation
 - `src/engine.ts`: execution loop, confirmations, retries, rollback/restart
-- `src/mockExecutor.ts`: mock step executor for simulation
+- `src/piAgentExecutor.ts`: default PI Agent executor using input/output files
+- `src/mockExecutor.ts`: explicit mock step executor for simulation
 - `src/events.ts`: event sequencing/logging
 - `src/types.ts`: contracts and status enums
 - `apps/remote-registry/`: React + Vite remote registry app
@@ -56,6 +57,8 @@ wfm search bunny
 wfm publish ./example-workflow.json --visibility public --tag storytelling,example
 wfm pull alice/remote-bunny --output ./remote-bunny.json
 ```
+
+Task steps run with the `pi-agent` adapter by default when `taskSpec.adapterKey` is omitted. The runner invokes PI Agent from the terminal with JSON input/output files, passing `taskSpec.init` skills, MCP endpoints, system prompts, model, and context into the input file. Set `WFM_PI_AGENT_COMMAND=/path/to/pi-agent` to override the default `pi-agent` binary, or set `taskSpec.payload.command` and `taskSpec.payload.args` for a specific step. Use `adapterKey: mock` explicitly for deterministic simulation workflows.
 
 During `wfm run`, the CLI starts a local attach API on `127.0.0.1`. Use `--port <n>` to bind a fixed port or omit it to let the OS choose one. The CLI prints the attach base URL and bearer token before execution starts.
 

--- a/doc/guide/architecture.md
+++ b/doc/guide/architecture.md
@@ -51,12 +51,13 @@ This repository already aligns to the same seam lines through `types`, `parser`,
 
 ## Ways to implement execution backends
 
-1. Keep `mock` for local simulation and tests.
-2. Add adapter executors behind a common execution interface.
-3. Route execution by `taskSpec.adapterKey`.
-4. Preserve `InputEnvelope`/`OutputEnvelope` compatibility to keep engine logic unchanged.
+1. Use `pi-agent` as the default task adapter when `taskSpec.adapterKey` is omitted.
+2. Keep `mock` for local simulation and tests.
+3. Add adapter executors behind a common execution interface.
+4. Route execution by resolved `taskSpec.adapterKey`.
+5. Preserve `InputEnvelope`/`OutputEnvelope` compatibility to keep engine logic unchanged.
 
-This allows adding real `opencode`, `codex`, or `claude-code` executors without changing workflow definitions.
+This allows PI Agent and real `opencode`, `codex`, or `claude-code` executors to share workflow definitions.
 
 ## Related docs
 

--- a/doc/guide/how-it-works.md
+++ b/doc/guide/how-it-works.md
@@ -9,7 +9,7 @@
 3. Initialize run state (`queued` -> `running`) and create a `StepRun` for each step.
 4. Execute steps in order, enforcing `dependsOn` before each step starts.
 5. Build an input envelope with global state, step context, and adapter init data.
-6. Execute the step (currently through the mock executor).
+6. Execute the step with PI Agent by default, or with an explicit adapter such as `mock`, `opencode`, `codex`, or `claude-code`.
 7. Apply validation and confirmation policy.
 8. Resolve routing actions (`RETRY_CURRENT`, `ROLLBACK_PREVIOUS`, `RESTART_ALL`, or proceed).
 9. Record run and step events in sequence.

--- a/doc/guide/protocol.md
+++ b/doc/guide/protocol.md
@@ -33,7 +33,7 @@ In this repo, the input contract is represented by `InputEnvelope` in `src/types
     "mcp_endpoints": ["string"],
     "system_prompts": ["string"],
     "context": {},
-    "adapter": "mock | opencode | codex | claude-code",
+    "adapter": "pi-agent | mock | opencode | codex | claude-code",
     "model": "string"
   }
 }

--- a/doc/guide/workflow-schema.md
+++ b/doc/guide/workflow-schema.md
@@ -19,7 +19,10 @@ steps:
   - key: plan
     kind: task
     taskSpec:
-      adapterKey: mock
+      init:
+        skills: [planning]
+        mcps: [filesystem]
+        systemPrompts: [Keep the plan concise]
 ---
 ```
 
@@ -34,7 +37,11 @@ JSON:
       "key": "plan",
       "kind": "task",
       "taskSpec": {
-        "adapterKey": "mock"
+        "init": {
+          "skills": ["planning"],
+          "mcps": ["filesystem"],
+          "systemPrompts": ["Keep the plan concise"]
+        }
       }
     }
   ]
@@ -61,7 +68,7 @@ JSON:
 - `retryPolicy.maxAttempts`: step-level retry override
 - `validation.mode`: `none | human | external`
 - `validation.required`, `validation.autoConfirm`
-- `taskSpec.adapterKey`: `mock | opencode | codex | claude-code`
+- `taskSpec.adapterKey`: optional; omitted task adapters run with `pi-agent`. Explicit values are `pi-agent | mock | opencode | codex | claude-code`.
 - `taskSpec.init.context`
 - `taskSpec.init.skills`
 - `taskSpec.init.mcps`

--- a/doc/index.md
+++ b/doc/index.md
@@ -24,7 +24,7 @@ It is designed for agentic and human-in-the-loop execution where each step can h
 - Deterministic in-memory execution engine
 - Event timeline output for auditability
 - Validation support (`none`, `human`, `external`)
-- Step adapters (`mock`, `opencode`, `codex`, `claude-code`)
+- Step adapters (`pi-agent` by default, plus explicit `mock`, `opencode`, `codex`, `claude-code`)
 
 ## Quick links
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint:fix": "biome lint --write --error-on-warnings",
     "lint:staged": "lint-staged --relative --concurrent false",
     "man": "man ./man/wfm.1",
-    "test:unit": "bun test tests/parser.test.ts tests/engine.test.ts tests/mockExecutor.test.ts tests/opencodeExecutor.test.ts tests/claudeCodeExecutor.test.ts tests/skillResolver.test.ts tests/publish-bundle.test.ts tests/remote.test.ts tests/installer.test.ts tests/run-telemetry.test.ts tests/runnerApi.test.ts tests/runnerCli.test.ts tests/supabase-functions.test.ts tests/supabase-ops.test.ts tests/remote-registry-app.test.ts",
+    "test:unit": "bun test tests/parser.test.ts tests/engine.test.ts tests/mockExecutor.test.ts tests/opencodeExecutor.test.ts tests/claudeCodeExecutor.test.ts tests/piAgentExecutor.test.ts tests/skillResolver.test.ts tests/publish-bundle.test.ts tests/remote.test.ts tests/installer.test.ts tests/run-telemetry.test.ts tests/runnerApi.test.ts tests/runnerCli.test.ts tests/supabase-functions.test.ts tests/supabase-ops.test.ts tests/remote-registry-app.test.ts",
     "test:e2e": "bun test tests/story-workflow.e2e.test.ts tests/opencode-real.e2e.test.ts",
     "test:e2e:real": "WORKFLOW_MANAGER_REAL_OPENCODE=1 bun test tests/opencode-real.e2e.test.ts",
     "test": "bun test",

--- a/skills/workflow-manager-cli/SKILL.md
+++ b/skills/workflow-manager-cli/SKILL.md
@@ -90,7 +90,9 @@ wfm pull alice/remote-bunny --output ./remote-bunny.json
 
 ## Adapter and validation notes
 
-- Supported adapters include `mock`, `opencode`, `codex`, and `claude-code`
+- Supported adapters include default `pi-agent` plus explicit `mock`, `opencode`, `codex`, and `claude-code`
+- Omit `taskSpec.adapterKey` to run a task with PI Agent using terminal input/output files
+- Put skills, MCP endpoints, system prompts, model, and context under `taskSpec.init`
 - Human approvals should stay explicit in workflow definitions
 - External validation should be deterministic where possible
 - Use the mock adapter for fast tests and scaffolding flows

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -1,0 +1,15 @@
+import type { AdapterKey } from "./types.js";
+
+export const DEFAULT_TASK_ADAPTER: AdapterKey = "pi-agent";
+
+export const SUPPORTED_ADAPTERS: readonly AdapterKey[] = [
+  "pi-agent",
+  "mock",
+  "opencode",
+  "codex",
+  "claude-code",
+] as const;
+
+export function resolveTaskAdapter(adapter?: AdapterKey): AdapterKey {
+  return adapter ?? DEFAULT_TASK_ADAPTER;
+}

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,9 +1,11 @@
 import { randomUUID } from "node:crypto";
 import { createInterface } from "node:readline";
+import { resolveTaskAdapter } from "./adapters.js";
 import { EventLog } from "./events.js";
 import { executeClaudeCodeStep, shouldUseRealClaudeCode } from "./claudeCodeExecutor.js";
 import { executeMockStep } from "./mockExecutor.js";
 import { executeOpencodeStep, shouldUseRealOpencode } from "./opencodeExecutor.js";
+import { executePiAgentStep } from "./piAgentExecutor.js";
 import type {
   ApprovalPreview,
   ApprovalDecisionPayload,
@@ -38,7 +40,7 @@ function nodeType(step: StepDefinition): "AGENT" | "HUMAN" | "SYSTEM" {
 }
 
 function stepAdapter(step: StepDefinition): StepDetailSnapshot["adapter"] {
-  return step.taskSpec?.adapterKey ?? "approval";
+  return step.kind === "task" ? resolveTaskAdapter(step.taskSpec?.adapterKey) : "approval";
 }
 
 function stepObjective(step: StepDefinition, workflowObjective: string): string {
@@ -298,7 +300,15 @@ async function executeStep(
   workflowFilePath: string,
   hooks?: StepExecutionHooks
 ): Promise<OutputEnvelope> {
-  const adapterKey = step.taskSpec?.adapterKey ?? "mock";
+  if (step.kind !== "task") {
+    return executeMockStep(step, input, attempt, hooks);
+  }
+
+  const adapterKey = resolveTaskAdapter(step.taskSpec?.adapterKey);
+
+  if (adapterKey === "pi-agent") {
+    return executePiAgentStep(step, input, attempt, workflow, workflowFilePath, hooks);
+  }
 
   if (adapterKey === "opencode" && shouldUseRealOpencode(step)) {
     return executeOpencodeStep(step, input, attempt, hooks);
@@ -629,7 +639,7 @@ export async function runWorkflow(definition: WorkflowDefinition, options?: RunO
         mcp_endpoints: step.taskSpec?.init?.mcps ?? [],
         system_prompts: step.taskSpec?.init?.systemPrompts ?? [],
         context: step.taskSpec?.init?.context,
-        adapter: step.taskSpec?.adapterKey ?? "mock",
+        adapter: resolveTaskAdapter(step.taskSpec?.adapterKey),
         model: step.taskSpec?.init?.model,
       },
     };
@@ -665,7 +675,7 @@ export async function runWorkflow(definition: WorkflowDefinition, options?: RunO
         status: output.execution_status,
         action: output.qa_routing.action,
         feedbackReason: output.qa_routing.feedback_reason,
-        adapter: step.taskSpec?.adapterKey ?? "mock",
+        adapter: resolveTaskAdapter(step.taskSpec?.adapterKey),
         init: {
           skills: step.taskSpec?.init?.skills ?? [],
           mcps: step.taskSpec?.init?.mcps ?? [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ const DISCOVERY_QUESTIONS = [
   "2) Which steps require human validation vs external validation?",
   "3) Which approvals are mandatory and who can confirm each approval?",
   "4) Which steps require explicit confirmation before proceeding?",
-  "5) For each step, which adapter should run it (opencode, codex, claude-code, mock)?",
+  "5) For each step, should it use the default PI Agent adapter or an explicit adapter (mock, opencode, codex, claude-code)?",
   "6) What per-step initialization is needed (context, skills, MCPs, system prompts, model)?",
   "7) What output format should this session produce (JSON run report, markdown summary, event timeline)?",
   "8) What retry/rollback policy should be default and where should exceptions apply?",
@@ -97,7 +97,7 @@ function cmdQuestions(): void {
   console.log("\nExpected output of this session:");
   console.log("- Finalized workflow file (markdown or json) with per-step objectives");
   console.log("- Validation/approval confirmation map per step");
-  console.log("- Adapter init map (opencode/codex/claude-code with context+skills+mcps)");
+  console.log("- Adapter init map (default PI Agent or explicit adapter with context+skills+mcps)");
   console.log("- Runnable CLI command examples + run JSON output");
 }
 
@@ -126,7 +126,6 @@ const WORKFLOW_SCAFFOLD_JSON: WorkflowDefinition = {
       dependsOn: [],
       validation: { mode: "human", required: true, autoConfirm: false },
       taskSpec: {
-        adapterKey: "opencode",
         init: {
           context: { repo: "example/repo" },
           skills: ["architecture", "planning"],
@@ -211,7 +210,6 @@ steps:
       required: true
       autoConfirm: false
     taskSpec:
-      adapterKey: opencode
       init:
         context:
           repo: example/repo

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2,9 +2,9 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import matter from "gray-matter";
+import { SUPPORTED_ADAPTERS, resolveTaskAdapter } from "./adapters.js";
 import type { AdapterKey, SkillEntry, WorkflowDefinition } from "./types.js";
 
-const SUPPORTED_ADAPTERS: AdapterKey[] = ["mock", "opencode", "codex", "claude-code"];
 const SKILL_NAME_PATTERN = /^[a-zA-Z0-9_.-]+$/;
 
 function hashContentSha256(content: string): string {
@@ -81,7 +81,7 @@ function normalizeWorkflow(data: Partial<WorkflowDefinition>, source: string): W
       taskSpec: s.taskSpec
         ? {
             ...s.taskSpec,
-            adapterKey: (s.taskSpec.adapterKey ?? "mock") as AdapterKey,
+            adapterKey: resolveTaskAdapter(s.taskSpec.adapterKey as AdapterKey | undefined),
             init: {
               context: s.taskSpec.init?.context ?? {},
               skills: s.taskSpec.init?.skills ?? [],

--- a/src/piAgentExecutor.ts
+++ b/src/piAgentExecutor.ts
@@ -1,0 +1,307 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { resolveSkill } from "./skillResolver.js";
+import type { InputEnvelope, OutputEnvelope, StepDefinition, StepExecutionHooks, WorkflowDefinition } from "./types.js";
+
+interface ResolvedPiSkill {
+  name: string;
+  origin: string;
+  content: string;
+}
+
+interface PiAgentInputFile {
+  input_envelope: InputEnvelope;
+  step: StepDefinition;
+  workflow?: Pick<WorkflowDefinition, "key" | "title" | "description" | "objectives" | "inputSchema" | "outputSchema">;
+  resolved_skills: ResolvedPiSkill[];
+  run: {
+    attempt: number;
+    runDir: string;
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+export function normalizeTimeout(value: unknown, fallbackMs = 600000): number {
+  const timeout = Number(value ?? fallbackMs);
+  if (!Number.isFinite(timeout) || timeout <= 0) return fallbackMs;
+  return Math.floor(timeout);
+}
+
+function makeResult(
+  step: StepDefinition,
+  input: InputEnvelope,
+  attempt: number,
+  startedAt: number,
+  status: OutputEnvelope["execution_status"],
+  reason: string,
+  extra: Record<string, unknown> = {},
+  action: OutputEnvelope["qa_routing"]["action"] = "PROCEED"
+): OutputEnvelope {
+  return {
+    step_id: step.key,
+    execution_status: status,
+    qa_routing: { action, feedback_reason: reason },
+    mutated_payload: {
+      stepKey: step.key,
+      attempt,
+      adapter: input.priming_configuration.adapter ?? "pi-agent",
+      ...extra,
+    },
+    metadata: {
+      execution_time_ms: Date.now() - startedAt,
+      external_intervention_required: false,
+    },
+  };
+}
+
+function resolveCommand(payload: Record<string, unknown>): string {
+  if (typeof payload.command === "string" && payload.command.trim()) return payload.command;
+  if (process.env.WFM_PI_AGENT_COMMAND?.trim()) return process.env.WFM_PI_AGENT_COMMAND;
+  return "pi-agent";
+}
+
+function resolveArgs(payload: Record<string, unknown>): string[] {
+  return Array.isArray(payload.args) ? payload.args.map((arg) => String(arg)) : [];
+}
+
+function resolveRunDir(payload: Record<string, unknown>): string {
+  if (typeof payload.runDir === "string" && payload.runDir.trim()) {
+    fs.mkdirSync(payload.runDir, { recursive: true });
+    return payload.runDir;
+  }
+
+  return fs.mkdtempSync(path.join(os.tmpdir(), "wfm-pi-agent-"));
+}
+
+function buildInputFile(
+  step: StepDefinition,
+  input: InputEnvelope,
+  attempt: number,
+  runDir: string,
+  workflow?: WorkflowDefinition,
+  workflowFilePath?: string
+): PiAgentInputFile {
+  const resolvedSkills: ResolvedPiSkill[] = [];
+  if (workflow && workflowFilePath) {
+    for (const name of input.priming_configuration.required_skills) {
+      const resolved = resolveSkill(name, workflow, workflowFilePath);
+      if (resolved) {
+        resolvedSkills.push({ name, origin: resolved.origin, content: resolved.content });
+      }
+    }
+  }
+
+  return {
+    input_envelope: input,
+    step,
+    workflow: workflow
+      ? {
+          key: workflow.key,
+          title: workflow.title,
+          description: workflow.description,
+          objectives: workflow.objectives,
+          inputSchema: workflow.inputSchema,
+          outputSchema: workflow.outputSchema,
+        }
+      : undefined,
+    resolved_skills: resolvedSkills,
+    run: { attempt, runDir },
+  };
+}
+
+function appendPrimingArgs(args: string[], input: InputEnvelope): void {
+  for (const skill of input.priming_configuration.required_skills) args.push("--skill", skill);
+  for (const mcp of input.priming_configuration.mcp_endpoints) args.push("--mcp", mcp);
+  for (const prompt of input.priming_configuration.system_prompts) args.push("--system-prompt", prompt);
+  if (input.priming_configuration.model) args.push("--model", input.priming_configuration.model);
+}
+
+function normalizeOutputEnvelope(
+  raw: unknown,
+  step: StepDefinition,
+  input: InputEnvelope,
+  attempt: number,
+  startedAt: number
+): OutputEnvelope {
+  const record = asRecord(raw);
+  const metadata = asRecord(record.metadata);
+  const qaRouting = asRecord(record.qa_routing);
+  const status = String(record.execution_status ?? "SUCCESS") as OutputEnvelope["execution_status"];
+  const action = String(qaRouting.action ?? "PROCEED") as OutputEnvelope["qa_routing"]["action"];
+
+  return {
+    step_id: typeof record.step_id === "string" && record.step_id.trim() ? record.step_id : step.key,
+    execution_status: status,
+    qa_routing: {
+      action,
+      feedback_reason: typeof qaRouting.feedback_reason === "string" ? qaRouting.feedback_reason : "",
+    },
+    mutated_payload: {
+      stepKey: step.key,
+      attempt,
+      adapter: input.priming_configuration.adapter ?? "pi-agent",
+      ...asRecord(record.mutated_payload),
+    },
+    metadata: {
+      execution_time_ms:
+        typeof metadata.execution_time_ms === "number" ? metadata.execution_time_ms : Date.now() - startedAt,
+      external_intervention_required: metadata.external_intervention_required === true,
+      intervention_details: asRecord(metadata.intervention_details),
+    },
+  };
+}
+
+export function executePiAgentStep(
+  step: StepDefinition,
+  input: InputEnvelope,
+  attempt: number,
+  workflow?: WorkflowDefinition,
+  workflowFilePath?: string,
+  hooks?: StepExecutionHooks
+): Promise<OutputEnvelope> {
+  const startedAt = Date.now();
+  const payload = asRecord(step.taskSpec?.payload);
+  const timeoutMs = normalizeTimeout(payload.timeoutMs);
+  const runDir = resolveRunDir(payload);
+  const inputPath = path.join(runDir, "input.json");
+  const outputPath = path.join(runDir, "output.json");
+  const command = resolveCommand(payload);
+  const args = resolveArgs(payload);
+  args.push("--input", inputPath, "--output", outputPath);
+  appendPrimingArgs(args, input);
+
+  fs.writeFileSync(
+    inputPath,
+    JSON.stringify(buildInputFile(step, input, attempt, runDir, workflow, workflowFilePath), null, 2),
+    "utf-8"
+  );
+
+  return new Promise((resolve) => {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    } catch (err) {
+      resolve(
+        makeResult(step, input, attempt, startedAt, "FAILED", (err as Error).message, {
+          command,
+          args,
+          inputPath,
+          outputPath,
+          timeoutMs,
+        })
+      );
+      return;
+    }
+
+    hooks?.onStarted?.({ command, args, inputPath, outputPath, timeoutMs });
+
+    const outChunks: string[] = [];
+    const errChunks: string[] = [];
+
+    child.stdout?.setEncoding("utf-8");
+    child.stderr?.setEncoding("utf-8");
+    child.stdout?.on("data", (chunk: string) => {
+      outChunks.push(chunk);
+      hooks?.onStdout?.(chunk);
+    });
+    child.stderr?.on("data", (chunk: string) => {
+      errChunks.push(chunk);
+      hooks?.onStderr?.(chunk);
+    });
+
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+      const result = makeResult(
+        step,
+        input,
+        attempt,
+        startedAt,
+        "FAILED",
+        `timed out after ${timeoutMs}ms`,
+        { command, args, inputPath, outputPath, timeoutMs, stdout: outChunks.join(""), stderr: errChunks.join("") }
+      );
+      hooks?.onFinished?.({ executionStatus: result.execution_status, timedOut: true });
+      resolve(result);
+    }, timeoutMs);
+
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      if (timedOut) return;
+      const result = makeResult(step, input, attempt, startedAt, "FAILED", err.message, {
+        command,
+        args,
+        inputPath,
+        outputPath,
+        timeoutMs,
+        stdout: outChunks.join(""),
+        stderr: errChunks.join(""),
+      });
+      hooks?.onFinished?.({ executionStatus: result.execution_status });
+      resolve(result);
+    });
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (timedOut) return;
+      const stdout = outChunks.join("");
+      const stderr = errChunks.join("");
+      const exitStatus = code ?? 1;
+
+      if (exitStatus !== 0) {
+        const result = makeResult(step, input, attempt, startedAt, "FAILED", `${command} exited with status ${exitStatus}`, {
+          command,
+          args,
+          inputPath,
+          outputPath,
+          exitStatus,
+          stdout,
+          stderr,
+        });
+        hooks?.onFinished?.({ executionStatus: result.execution_status, exitStatus });
+        resolve(result);
+        return;
+      }
+
+      if (!fs.existsSync(outputPath)) {
+        const result = makeResult(step, input, attempt, startedAt, "FAILED", `PI Agent output file not found: ${outputPath}`, {
+          command,
+          args,
+          inputPath,
+          outputPath,
+          exitStatus,
+          stdout,
+          stderr,
+        });
+        hooks?.onFinished?.({ executionStatus: result.execution_status, exitStatus });
+        resolve(result);
+        return;
+      }
+
+      try {
+        const rawOutput = JSON.parse(fs.readFileSync(outputPath, "utf-8")) as unknown;
+        const result = normalizeOutputEnvelope(rawOutput, step, input, attempt, startedAt);
+        hooks?.onFinished?.({ executionStatus: result.execution_status, exitStatus });
+        resolve(result);
+      } catch (err) {
+        const result = makeResult(step, input, attempt, startedAt, "FAILED", `Invalid PI Agent output: ${(err as Error).message}`, {
+          command,
+          args,
+          inputPath,
+          outputPath,
+          exitStatus,
+          stdout,
+          stderr,
+        });
+        hooks?.onFinished?.({ executionStatus: result.execution_status, exitStatus });
+        resolve(result);
+      }
+    });
+  });
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,7 @@ export type NodeType = "AGENT" | "HUMAN" | "SYSTEM";
 export type ExecutionStatus = "SUCCESS" | "QA_REJECTED" | "YIELD_EXTERNAL" | "FAILED";
 export type QaAction = "PROCEED" | "RETRY_CURRENT" | "ROLLBACK_PREVIOUS" | "RESTART_ALL";
 export type ValidationMode = "none" | "human" | "external";
-export type AdapterKey = "mock" | "opencode" | "codex" | "claude-code";
+export type AdapterKey = "pi-agent" | "mock" | "opencode" | "codex" | "claude-code";
 
 export interface RetryPolicy {
   maxAttempts?: number;

--- a/supabase/functions/_shared/workflows.ts
+++ b/supabase/functions/_shared/workflows.ts
@@ -1,6 +1,6 @@
 import { HttpError } from "./responses.ts";
 
-const supportedAdapters = new Set(["mock", "opencode", "codex", "claude-code"]);
+const supportedAdapters = new Set(["pi-agent", "mock", "opencode", "codex", "claude-code"]);
 const supportedValidationModes = new Set(["none", "human", "external"]);
 const supportedSourceFormats = new Set(["markdown", "json"]);
 const supportedVisibility = new Set(["public", "private"]);

--- a/tests/engine.test.ts
+++ b/tests/engine.test.ts
@@ -1,8 +1,52 @@
 import { describe, expect, it } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { canUseInteractiveConfirmation, runWorkflow } from "../src/engine.ts";
 import type { RunSnapshot, WorkflowDefinition } from "../src/types.ts";
+import { fakePiAgentScript } from "./helpers/piAgentFake.ts";
 
 describe("engine routing", () => {
+  it("routes omitted task adapters through pi-agent by default", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wfm-engine-pi-agent-"));
+    const script = fakePiAgentScript(dir);
+    const wf: WorkflowDefinition = {
+      key: "default-pi-wf",
+      title: "Default PI WF",
+      steps: [
+        {
+          key: "implement",
+          kind: "task",
+          objective: "Implement feature",
+          validation: { mode: "none", required: false, autoConfirm: true },
+          taskSpec: {
+            init: {
+              skills: ["test-driven-development"],
+              mcps: ["filesystem"],
+              systemPrompts: ["Use TDD"],
+              context: { repo: "workflow-manager" },
+            },
+            payload: { command: process.execPath, args: [script], runDir: dir, timeoutMs: 5000 },
+          },
+        },
+      ],
+    };
+
+    const result = await runWorkflow(wf, { autoConfirmAll: true });
+
+    expect(result.status).toBe("succeeded");
+    expect(result.outputs.implement).toMatchObject({
+      adapter: "pi-agent",
+      sawSkills: ["test-driven-development"],
+      sawMcps: ["filesystem"],
+    });
+    expect(
+      result.events.some(
+        (event) => event.type === "step.execution_finished" && event.payload.adapter === "pi-agent"
+      )
+    ).toBe(true);
+  });
+
   it("retries current step and succeeds", async () => {
     let flips = 0;
     const wf: WorkflowDefinition = {

--- a/tests/helpers/piAgentFake.ts
+++ b/tests/helpers/piAgentFake.ts
@@ -1,0 +1,12 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export function fakePiAgentScript(dir: string): string {
+  const script = path.join(dir, "fake-pi-agent.mjs");
+  fs.writeFileSync(
+    script,
+    `import fs from "node:fs";\nconst inputPath = process.argv[process.argv.indexOf("--input") + 1];\nconst outputPath = process.argv[process.argv.indexOf("--output") + 1];\nconst payload = JSON.parse(fs.readFileSync(inputPath, "utf-8"));\nfs.writeFileSync(outputPath, JSON.stringify({\n  step_id: payload.input_envelope.step_context.step_id,\n  execution_status: "SUCCESS",\n  qa_routing: { action: "PROCEED", feedback_reason: "" },\n  mutated_payload: {\n    sawSkills: payload.input_envelope.priming_configuration.required_skills,\n    sawMcps: payload.input_envelope.priming_configuration.mcp_endpoints,\n    sawSystemPrompts: payload.input_envelope.priming_configuration.system_prompts,\n    sawContext: payload.input_envelope.priming_configuration.context,\n    sawModel: payload.input_envelope.priming_configuration.model,\n    sawAttempt: payload.run.attempt\n  },\n  metadata: { execution_time_ms: 1, external_intervention_required: false }\n}));\n`,
+    "utf-8"
+  );
+  return script;
+}

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -77,6 +77,33 @@ steps:
     expect(validateWorkflow(wf)).toEqual([]);
   });
 
+  it("defaults omitted task adapters to pi-agent", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wm-"));
+    const file = path.join(dir, "wf-default-adapter.json");
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        key: "default-adapter",
+        title: "Default Adapter",
+        steps: [{ key: "s1", kind: "task", taskSpec: {} }],
+      }),
+      "utf-8"
+    );
+
+    const wf = parseWorkflowFile(file);
+    expect(wf.steps[0].taskSpec?.adapterKey).toBe("pi-agent");
+  });
+
+  it("validates pi-agent as a supported adapter", () => {
+    const errors = validateWorkflow({
+      key: "pi-agent-wf",
+      title: "PI Agent WF",
+      steps: [{ key: "s1", kind: "task", taskSpec: { adapterKey: "pi-agent" } }],
+    });
+
+    expect(errors).toEqual([]);
+  });
+
   it("auto-detects parser from file extension", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wm-"));
     const jsonFile = path.join(dir, "wf.json");

--- a/tests/piAgentExecutor.test.ts
+++ b/tests/piAgentExecutor.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { executePiAgentStep, normalizeTimeout } from "../src/piAgentExecutor.ts";
+import type { InputEnvelope, StepDefinition } from "../src/types.ts";
+import { fakePiAgentScript } from "./helpers/piAgentFake.ts";
+
+function baseInput(): InputEnvelope {
+  return {
+    global_context: {
+      workflow_id: "run-1",
+      primary_objective: "test workflow",
+      workflow_objectives: [],
+      global_state: { feature: "PI Agent adapter" },
+    },
+    step_context: {
+      step_id: "implement",
+      step_objective: "Implement the feature",
+      previous_output: {},
+      assigned_node_type: "AGENT",
+    },
+    priming_configuration: {
+      required_skills: ["test-driven-development"],
+      mcp_endpoints: ["filesystem"],
+      system_prompts: ["Use TDD"],
+      context: { repo: "workflow-manager" },
+      adapter: "pi-agent",
+      model: "openai/gpt-5.4-mini",
+    },
+  };
+}
+
+function baseStep(payloadOverrides: Record<string, unknown> = {}): StepDefinition {
+  return {
+    key: "implement",
+    kind: "task",
+    objective: "Implement the feature",
+    taskSpec: {
+      adapterKey: "pi-agent",
+      payload: {
+        timeoutMs: 5000,
+        ...payloadOverrides,
+      },
+    },
+  };
+}
+
+describe("piAgentExecutor", () => {
+  it("normalizes invalid timeout values", () => {
+    expect(normalizeTimeout("not-a-number")).toBe(600000);
+    expect(normalizeTimeout(-1)).toBe(600000);
+    expect(normalizeTimeout(0)).toBe(600000);
+    expect(normalizeTimeout(5000)).toBe(5000);
+  });
+
+  it("returns a failed OutputEnvelope when the command cannot be spawned", async () => {
+    const result = await executePiAgentStep(
+      baseStep({ command: "/definitely/not/a/pi-agent", timeoutMs: 100 }),
+      baseInput(),
+      1
+    );
+
+    expect(result.step_id).toBe("implement");
+    expect(result.execution_status).toBe("FAILED");
+    expect(result.mutated_payload.adapter).toBe("pi-agent");
+    expect(String(result.qa_routing.feedback_reason)).toContain("not");
+  });
+
+  it("writes input files and reads PI Agent output files", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wfm-pi-agent-test-"));
+    const script = fakePiAgentScript(dir);
+
+    const result = await executePiAgentStep(
+      baseStep({ command: process.execPath, args: [script], runDir: dir }),
+      baseInput(),
+      2
+    );
+
+    expect(result.execution_status).toBe("SUCCESS");
+    expect(result.mutated_payload.sawSkills).toEqual(["test-driven-development"]);
+    expect(result.mutated_payload.sawMcps).toEqual(["filesystem"]);
+    expect(result.mutated_payload.sawSystemPrompts).toEqual(["Use TDD"]);
+    expect(result.mutated_payload.sawContext).toEqual({ repo: "workflow-manager" });
+    expect(result.mutated_payload.sawModel).toBe("openai/gpt-5.4-mini");
+    expect(result.mutated_payload.sawAttempt).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Makes PI Agent the default task adapter when `taskSpec.adapterKey` is omitted.
- Adds a PI Agent executor that runs via terminal input/output JSON files and passes step init config: skills, MCPs, system prompts, model, and context.
- Keeps explicit `mock`, `opencode`, `codex`, and `claude-code` support, and updates docs/schema guidance.

## Why
Requested from chat to validate the PI Agent default adapter behavior in CI via a PR.

## How
- Centralized adapter defaults in `src/adapters.ts`.
- Added `src/piAgentExecutor.ts` with command overrides through `WFM_PI_AGENT_COMMAND` or per-step `taskSpec.payload.command`/`args`.
- Routed task execution through PI Agent by default, while approval/system steps keep mock executor behavior.
- Added fake PI Agent tests so CI does not need the real PI Agent binary.

## Validation
- `bun run lint` ✅
- `bun test` ✅ — 151 pass, 2 skipped
- `bun run build` ✅
- `bun run docs:build` ✅

## Docs
Updated:
- `README.md`
- `doc/index.md`
- `doc/guide/architecture.md`
- `doc/guide/how-it-works.md`
- `doc/guide/protocol.md`
- `doc/guide/workflow-schema.md`
- `skills/workflow-manager-cli/SKILL.md`

## Risk / rollout
- Existing workflows that omit `taskSpec.adapterKey` now run PI Agent instead of mock. Deterministic simulations should set `adapterKey: mock` explicitly.
- Runtime command defaults to `pi-agent`; deployments can override with `WFM_PI_AGENT_COMMAND`.
