### PR TITLE
feat(cli): add agent rules command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If `wfm` is not available immediately in the same terminal, run the shell reload
 
 ## Architecture
 
-- `src/index.ts`: CLI commands (`questions`, `scaffold`, `validate`, `run`)
+- `src/index.ts`: CLI commands (`doctor`, `agent`, `scaffold`, `validate`, `run`)
 - `src/parser.ts`: parsing + validation
 - `src/engine.ts`: execution loop, confirmations, retries, rollback/restart
 - `src/piAgentExecutor.ts`: default PI Agent executor using input/output files
@@ -42,6 +42,7 @@ bun run build
 bun link
 
 wfm doctor
+wfm agent ./AGENTS.md
 wfm scaffold ./example-workflow.md
 wfm validate ./example-workflow.md
 wfm doctor ./example-workflow.md
@@ -202,6 +203,12 @@ Manual help:
 
 ```bash
 wfm man
+```
+
+Agent rules:
+
+```bash
+wfm agent ./AGENTS.md
 ```
 
 Remote registry commands:

--- a/doc/guide/getting-started.md
+++ b/doc/guide/getting-started.md
@@ -28,9 +28,11 @@ wfm --help
 ## Core CLI commands
 
 ```bash
-wfm questions
+wfm doctor
+wfm agent ./AGENTS.md
 wfm scaffold ./example-workflow.md
 wfm validate ./example-workflow.md
+wfm doctor ./example-workflow.md
 wfm run ./example-workflow.md --confirm discover,qa_gate:human
 wfm run ./example-workflow.md --auto-confirm-all --verbose
 
@@ -52,11 +54,13 @@ wfm pull alice/remote-bunny --output ./remote-bunny.json
 
 ## Typical workflow
 
-1. Run `wfm questions` to gather design requirements for a new workflow.
-2. Run `wfm scaffold ./example-workflow.md` to generate a starter file.
-3. Edit frontmatter (Markdown) or JSON fields with your steps, dependencies, validation, and adapter init config.
-4. Run `wfm validate ./example-workflow.md` or `wfm validate ./example-workflow.json` until validation passes.
-5. Run `wfm run <workflow-file>` to watch live progress in the CLI. Human approvals now show an inline terminal review prompt, and `--verbose` streams per-step agent output.
+1. Run `wfm doctor` to inspect host adapter and key setup.
+2. Run `wfm agent ./AGENTS.md` when you want local agent rules for using WFM safely.
+3. Run `wfm scaffold ./example-workflow.md` to generate a starter file.
+4. Edit frontmatter (Markdown) or JSON fields with your steps, dependencies, validation, and adapter init config.
+5. Run `wfm validate ./example-workflow.md` or `wfm validate ./example-workflow.json` until validation passes.
+6. Run `wfm doctor <workflow-file>` before real adapter runs.
+7. Run `wfm run <workflow-file>` to watch live progress in the CLI. Human approvals now show an inline terminal review prompt, and `--verbose` streams per-step agent output.
 
 ## Remote registry workflow
 

--- a/skills/workflow-manager-cli/SKILL.md
+++ b/skills/workflow-manager-cli/SKILL.md
@@ -3,7 +3,7 @@ name: @workflow-manager/runner/cli
 description: >
   Load this skill when working with the wfm CLI from @workflow-manager/runner, authoring or
   validating workflow definitions, configuring step skills and adapters, or
-  publishing workflows to the remote registry. Covers questions, scaffold,
+  publishing workflows to the remote registry. Covers doctor, agent, scaffold,
   validate, run, auth, publish, pull, search, and remote info.
 type: core
 library: @workflow-manager/runner
@@ -25,6 +25,7 @@ Use this skill when you need to create or operate `workflow-manager` workflows f
 Use it when the user wants to:
 
 - scaffold a new workflow definition
+- create local agent rules for WFM usage
 - validate or run a workflow file
 - configure approvals, retry policy, or adapter initialization
 - publish a workflow to the remote registry
@@ -35,17 +36,19 @@ Use it when the user wants to:
 
 Use this sequence unless the user asks for a narrower task:
 
-1. Discover the workflow intent with `wfm questions`
-2. Scaffold a starter file with `wfm scaffold`
-3. Edit the workflow definition
-4. Validate the file with `wfm validate`
-5. Execute it with `wfm run`
-6. If needed, authenticate and publish with the remote registry commands
+1. Inspect local setup with `wfm doctor`
+2. Create project agent rules with `wfm agent` when local agent guidance is useful
+3. Scaffold a starter file with `wfm scaffold`
+4. Edit the workflow definition
+5. Validate the file with `wfm validate`
+6. Execute it with `wfm run`
+7. If needed, authenticate and publish with the remote registry commands
 
 ## Local workflow commands
 
 ```bash
-wfm questions
+wfm doctor
+wfm agent ./AGENTS.md
 
 wfm scaffold ./example-workflow.md
 wfm scaffold ./example-workflow.json --format json

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,15 @@
 #!/usr/bin/env node
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { CliRunRenderer } from "./cliRunRenderer.js";
 import { startRunnerApiServer } from "./runnerApi.js";
 import { RunnerSessionStore } from "./runnerSession.js";
 import { parseWorkflowFile, validateWorkflow } from "./parser.js";
+import { MAN_PAGE_SOURCE } from "./manPage.js";
 import { promptForApprovalDecision, runWorkflow } from "./engine.js";
 import { cmdAuth, cmdPublish, cmdPull, cmdRemoteInfo, cmdSearch } from "./remote/commands.js";
 import { emitRunTelemetryBestEffort } from "./remote/telemetry.js";
@@ -16,17 +19,6 @@ import {
   validateRuntimeRequirements,
 } from "./runtimePreflight.js";
 import type { RunObserver, StepDetailSnapshot, WorkflowDefinition } from "./types.js";
-
-const DISCOVERY_QUESTIONS = [
-  "1) What set of workflow objectives should be tracked per run (one or many)?",
-  "2) Which steps require human validation vs external validation?",
-  "3) Which approvals are mandatory and who can confirm each approval?",
-  "4) Which steps require explicit confirmation before proceeding?",
-  "5) For each step, should it use the default PI Agent adapter or an explicit adapter (mock, opencode, codex, claude-code)?",
-  "6) What per-step initialization is needed (context, skills, MCPs, system prompts, model)?",
-  "7) What output format should this session produce (JSON run report, markdown summary, event timeline)?",
-  "8) What retry/rollback policy should be default and where should exceptions apply?",
-];
 
 function cliDisplayName(): string {
   const invokedAs = path.basename(process.argv[1] ?? "");
@@ -40,8 +32,8 @@ function cliDisplayName(): string {
 function usage(): void {
   const cli = cliDisplayName();
   console.log(`${cli} commands:
-  questions
   doctor [workflow.md|workflow.json] [--json]
+  agent [path] [--force]
   scaffold [path] [--format markdown|json]
   validate <workflow.md|workflow.json>
   run <workflow.md|workflow.json> [--input input.json] [--objective "string"] [--confirm stepA,stepB:human] [--auto-confirm-all] [--port 43121] [--verbose] [--json]
@@ -95,16 +87,6 @@ function combineRunObservers(...observers: Array<RunObserver | undefined>): RunO
       }
     },
   };
-}
-
-function cmdQuestions(): void {
-  console.log("Project definition questions:");
-  for (const q of DISCOVERY_QUESTIONS) console.log(`- ${q}`);
-  console.log("\nExpected output of this session:");
-  console.log("- Finalized workflow file (markdown or json) with per-step objectives");
-  console.log("- Validation/approval confirmation map per step");
-  console.log("- Adapter init map (default PI Agent or explicit adapter with context+skills+mcps)");
-  console.log("- Runnable CLI command examples + run JSON output");
 }
 
 const WORKFLOW_SCAFFOLD_JSON: WorkflowDefinition = {
@@ -280,6 +262,37 @@ steps:
 Edit frontmatter to configure orchestration behavior.
 `;
 
+const AGENT_RULES_TEMPLATE = `# WFM Agent Rules
+
+Use these rules when creating, validating, running, or publishing workflow-manager workflows with the \`wfm\` CLI.
+
+## Core Flow
+
+1. Start with \`wfm doctor\` to inspect local adapter and API key setup.
+2. Create a starter workflow with \`wfm scaffold ./workflow.md\` or \`wfm scaffold ./workflow.json --format json\`.
+3. Edit stable workflow keys, step objectives, dependencies, validation modes, and adapter initialization.
+4. Run \`wfm validate <workflow>\` before every run or publish.
+5. Run \`wfm doctor <workflow>\` before using real host-backed adapters.
+6. Run with \`wfm run <workflow>\`; use \`--verbose\` when agent logs are needed.
+7. Publish only after validation succeeds with \`wfm publish <workflow>\`.
+
+## Workflow Authoring
+
+- Keep workflow, step, and adapter keys stable; external tools and tests may reference them.
+- Omit \`taskSpec.adapterKey\` for the default \`pi-agent\` adapter.
+- Use \`adapterKey: mock\` for deterministic tests and examples.
+- Put skills, MCP endpoints, system prompts, model, and context under \`taskSpec.init\`.
+- Model-backed steps should declare required environment variables through provider-specific model names or \`taskSpec.payload.requiredEnv\`.
+- Human or external validation should be explicit in the workflow file.
+
+## Running Safely
+
+- Do not use \`--auto-confirm-all\` unless the workflow is intentionally non-interactive.
+- Prefer \`wfm doctor <workflow>\` before runs that use \`pi-agent\`, real \`opencode\`, or real \`claude-code\`.
+- Use the attach API output from \`wfm run\` for approval, resume, and cancel commands.
+- Preserve Markdown workflows when humans will review notes; use JSON for generated or machine-edited workflows.
+`;
+
 function resolveScaffoldFormat(targetPath: string, explicitFormat?: string): "markdown" | "json" {
   if (explicitFormat === "markdown" || explicitFormat === "json") {
     return explicitFormat;
@@ -309,6 +322,37 @@ function parseScaffoldArgs(args: string[]): { targetPath?: string; format?: stri
   return { targetPath, format };
 }
 
+function parseAgentArgs(args: string[]): { targetPath?: string; force: boolean } {
+  let targetPath: string | undefined;
+  let force = false;
+
+  for (const arg of args) {
+    if (arg === "--force" || arg === "-f") {
+      force = true;
+      continue;
+    }
+
+    if (!arg.startsWith("-") && !targetPath) {
+      targetPath = arg;
+    }
+  }
+
+  return { targetPath, force };
+}
+
+function cmdAgent(targetPath?: string, force = false): number {
+  const resolvedPath = path.resolve(targetPath ?? "./AGENTS.md");
+  if (fs.existsSync(resolvedPath) && !force) {
+    console.error(`Agent rules already exist at ${resolvedPath}. Pass --force to overwrite.`);
+    return 1;
+  }
+
+  fs.mkdirSync(path.dirname(resolvedPath), { recursive: true });
+  fs.writeFileSync(resolvedPath, AGENT_RULES_TEMPLATE, "utf-8");
+  console.log(`Wrote WFM agent rules: ${resolvedPath}`);
+  return 0;
+}
+
 function cmdScaffold(targetPath?: string, format?: string): number {
   const resolvedPath = targetPath ? path.resolve(targetPath) : path.resolve("./example-workflow.md");
   const normalizedFormat = format?.toLowerCase();
@@ -330,21 +374,40 @@ function cmdScaffold(targetPath?: string, format?: string): number {
 }
 
 function cmdMan(): number {
-  const manPagePath = path.resolve("./man/wfm.1");
+  const modulePath = fileURLToPath(import.meta.url);
+  const packageRoot = path.dirname(path.dirname(modulePath));
+  const candidatePaths = [path.join(packageRoot, "man", "wfm.1"), path.resolve("./man/wfm.1")];
+  const manPagePath = candidatePaths.find((candidatePath) => fs.existsSync(candidatePath));
 
-  if (!fs.existsSync(manPagePath)) {
-    console.error(`Man page not found at ${manPagePath}`);
-    return 1;
+  let fallbackSource = MAN_PAGE_SOURCE;
+  let tempDir: string | undefined;
+  const resolvedManPagePath =
+    manPagePath ??
+    (() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "wfm-man-"));
+      const tempManPagePath = path.join(tempDir, "wfm.1");
+      fs.writeFileSync(tempManPagePath, MAN_PAGE_SOURCE, "utf-8");
+      return tempManPagePath;
+    })();
+
+  if (manPagePath) {
+    fallbackSource = fs.readFileSync(manPagePath, "utf-8");
   }
 
-  const result = spawnSync("man", [manPagePath], { stdio: "inherit" });
-  if (result.status === 0) {
+  try {
+    const result = spawnSync("man", [resolvedManPagePath], { stdio: "inherit" });
+    if (result.status === 0) {
+      return 0;
+    }
+
+    console.log("\n' man ' command unavailable, printing page contents:\n");
+    console.log(fallbackSource);
     return 0;
+  } finally {
+    if (tempDir) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   }
-
-  console.log("\n' man ' command unavailable, printing page contents:\n");
-  console.log(fs.readFileSync(manPagePath, "utf-8"));
-  return 0;
 }
 
 function cmdValidate(filePath: string): number {
@@ -689,13 +752,13 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  if (cmd === "questions") {
-    cmdQuestions();
-    process.exit(0);
-  }
-
   if (cmd === "doctor") {
     process.exit(cmdDoctor(process.argv.slice(3)));
+  }
+
+  if (cmd === "agent") {
+    const { targetPath, force } = parseAgentArgs(process.argv.slice(3));
+    process.exit(cmdAgent(targetPath, force));
   }
 
   if (cmd === "scaffold") {

--- a/src/manPage.ts
+++ b/src/manPage.ts
@@ -1,6 +1,6 @@
-.TH WFM 1 "April 2026" "@workflow-manager/runner" "User Commands"
+export const MAN_PAGE_SOURCE = `.TH WFM 1 "April 2026" "@workflow-manager/runner" "User Commands"
 .SH NAME
-wfm \- run markdown or json workflows from the CLI
+wfm \\- run markdown or json workflows from the CLI
 .SH SYNOPSIS
 .B wfm
 .I command
@@ -144,3 +144,4 @@ Validation or runtime error.
 .TP
 .B 2
 Run completed in non-success terminal status.
+`;

--- a/tests/runnerCli.test.ts
+++ b/tests/runnerCli.test.ts
@@ -182,10 +182,14 @@ function startCli(args: string[]): RunningCli {
   };
 }
 
-async function runCommand(args: string[], envOverrides: NodeJS.ProcessEnv = {}): Promise<CliResult> {
+async function runCommand(
+  args: string[],
+  envOverrides: NodeJS.ProcessEnv = {},
+  cwd = process.cwd()
+): Promise<CliResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, ["./src/index.ts", ...args], {
-      cwd: process.cwd(),
+    const child = spawn(process.execPath, [path.join(process.cwd(), "src/index.ts"), ...args], {
+      cwd,
       env: { ...process.env, ...envOverrides },
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -278,6 +282,41 @@ describe("runner CLI attach API", () => {
     expect(result.stdout).toContain("Workflow Manager Doctor");
     expect(result.stdout).toContain("codex: mock");
     expect(result.stdout).toContain("OK workflow schema and runtime requirements");
+  });
+
+  it("prints agent instead of questions in usage", async () => {
+    const result = await runCommand(["--help"]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("agent [path] [--force]");
+    expect(result.stdout).not.toContain("questions");
+  });
+
+  it("writes WFM agent rules and protects existing files", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wm-runner-cli-agent-"));
+    tempDirs.push(dir);
+    const rulesPath = path.join(dir, "AGENTS.md");
+
+    const created = await runCommand(["agent", rulesPath]);
+    expect(created.status).toBe(0);
+    expect(created.stdout).toContain("Wrote WFM agent rules");
+    expect(fs.readFileSync(rulesPath, "utf-8")).toContain("wfm validate <workflow>");
+
+    const blocked = await runCommand(["agent", rulesPath]);
+    expect(blocked.status).toBe(1);
+    expect(blocked.stderr).toContain("Pass --force to overwrite");
+
+    const forced = await runCommand(["agent", rulesPath, "--force"]);
+    expect(forced.status).toBe(0);
+  });
+
+  it("prints the man page outside the repository root", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wm-runner-cli-man-"));
+    tempDirs.push(dir);
+    const result = await runCommand(["man"], {}, dir);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("run markdown or json workflows");
   });
 
   it("fails doctor for default PI Agent workflows when the host command is missing", async () => {


### PR DESCRIPTION
## Summary

- Fix `wfm man` so installed binaries no longer depend on the caller's current directory.
- Remove the low-value `wfm questions` command from the CLI surface.
- Add `wfm agent [path] [--force]` to create WFM-focused agent rules for local projects.

## Why

Requested from local CLI testing: `wfm man` failed outside the repo root, and `wfm questions` did not provide a useful workflow. The replacement command creates reusable agent guidance for using WFM correctly.

## How

- Resolve packaged man pages relative to the module location and fall back to an embedded man page source for standalone binaries.
- Add an `agent` command that writes WFM agent rules, defaults to `./AGENTS.md`, and protects existing files unless `--force` is passed.
- Update README, getting-started docs, man page, embedded man page, bundled skill guidance, and CLI regression tests.

## Validation

- `bun run lint` passed.
- `bun test` passed: 176 pass, 2 expected local-smoke skips.
- `bun run build` passed.
- `bun run docs:build` passed.
- Manual standalone binary checks passed from `/private/tmp`: `dist/wfm man`, `dist/wfm agent ...`, and `dist/wfm --help`.

## Docs

- Updated `README.md`.
- Updated `doc/guide/getting-started.md`.
- Updated `man/wfm.1` and embedded man page source.
- Updated `skills/workflow-manager-cli/SKILL.md`.

## Risk / rollout

- This removes `wfm questions`; users should use `wfm agent` for local agent guidance and `wfm scaffold` for workflow starters.
- Release Please should pick this up as a minor CLI feature because the commit is `feat(cli): add agent rules command`.
