### PR TITLE
fix(runner): resolve approval deadlock and stale pi-agent output reuse

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -673,23 +673,21 @@ async function cmdRun(filePath: string): Promise<number> {
             return null;
           }
 
-          if (decision.decision === "cancelled") {
-            sessionStore?.cancel(request.stepKey, {
-              actor: decision.actor,
-              note: decision.note,
-              source: decision.source,
-            });
-          } else {
-            const metadata = {
-              actor: decision.actor,
-              note: decision.note,
-              source: decision.source,
-            };
-            if (request.validation === "external") {
-              sessionStore?.resume(request.stepKey, metadata);
-            } else {
-              sessionStore?.approve(request.stepKey, metadata);
-            }
+          const metadata = {
+            actor: decision.actor,
+            note: decision.note,
+            source: decision.source,
+          };
+          const outcome =
+            decision.decision === "cancelled"
+              ? sessionStore?.cancel(request.stepKey, metadata)
+              : request.validation === "external"
+                ? sessionStore?.resume(request.stepKey, metadata)
+                : sessionStore?.approve(request.stepKey, metadata);
+          if (outcome && !outcome.ok) {
+            process.stderr.write(
+              `Could not apply terminal decision for ${request.stepKey}: ${outcome.reason ?? "unknown error"}\n`
+            );
           }
 
           return null;

--- a/src/piAgentExecutor.ts
+++ b/src/piAgentExecutor.ts
@@ -179,6 +179,9 @@ export function executePiAgentStep(
     runDir = resolveRunDir(payload);
     inputPath = path.join(runDir, "input.json");
     outputPath = path.join(runDir, "output.json");
+    // A fixed runDir is reused across attempts; a leftover output.json would be
+    // read as this attempt's result if the agent exits 0 without writing one.
+    fs.rmSync(outputPath, { force: true });
     command = resolveCommand(payload);
     args = resolveArgs(payload);
     args.push("--input", inputPath, "--output", outputPath);

--- a/src/runnerSession.ts
+++ b/src/runnerSession.ts
@@ -333,11 +333,14 @@ export class RunnerSessionStore implements RunObserver, RunController {
       };
     }
 
-    if (expectedValidation && this.pendingApproval.validation !== expectedValidation) {
+    // Waits with validation "none" (or unset) declare no expected resolution verb,
+    // so both approve and resume must be able to release them.
+    const pendingValidation = this.pendingApproval.validation ?? "none";
+    if (expectedValidation && pendingValidation !== "none" && pendingValidation !== expectedValidation) {
       const action = expectedValidation === "external" ? "resume" : "approve";
       return {
         ok: false,
-        reason: `Cannot ${action} ${this.pendingApproval.validation ?? "unknown"} validation for ${this.pendingApproval.stepKey}`,
+        reason: `Cannot ${action} ${pendingValidation} validation for ${this.pendingApproval.stepKey}`,
       };
     }
 

--- a/tests/piAgentExecutor.test.ts
+++ b/tests/piAgentExecutor.test.ts
@@ -100,4 +100,28 @@ describe("piAgentExecutor", () => {
     expect(result.mutated_payload.sawModel).toBe("openai/gpt-5.4-mini");
     expect(result.mutated_payload.sawAttempt).toBe(2);
   });
+
+  it("does not reuse a stale output file from a previous attempt in the same runDir", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wfm-pi-agent-stale-"));
+    const script = fakePiAgentScript(dir);
+
+    const first = await executePiAgentStep(
+      baseStep({ command: process.execPath, args: [script], runDir: dir }),
+      baseInput(),
+      1
+    );
+    expect(first.execution_status).toBe("SUCCESS");
+
+    const noopScript = path.join(dir, "noop-pi-agent.mjs");
+    fs.writeFileSync(noopScript, "process.exit(0);\n", "utf-8");
+
+    const second = await executePiAgentStep(
+      baseStep({ command: process.execPath, args: [noopScript], runDir: dir }),
+      baseInput(),
+      2
+    );
+
+    expect(second.execution_status).toBe("FAILED");
+    expect(second.qa_routing.feedback_reason).toContain("output file not found");
+  });
 });

--- a/tests/runnerApi.test.ts
+++ b/tests/runnerApi.test.ts
@@ -99,6 +99,41 @@ function externalApprovalWorkflow(): WorkflowDefinition {
   };
 }
 
+function noneValidationYieldWorkflow(): WorkflowDefinition {
+  return {
+    key: "runner-api-none-validation",
+    title: "Runner API None Validation",
+    steps: [
+      {
+        key: "handoff",
+        kind: "task",
+        objective: "Yield for external work without a declared validation mode",
+        validation: { mode: "none", required: false, autoConfirm: false },
+        taskSpec: {
+          adapterKey: "mock",
+          payload: { mockResult: "yield" },
+        },
+      },
+    ],
+  };
+}
+
+async function waitForApprovalValidation(
+  store: RunnerSessionStore,
+  validation: string,
+  timeoutMs = 3000
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (store.snapshot().waitingForApproval?.validation === validation) {
+      return;
+    }
+    await Bun.sleep(10);
+  }
+
+  throw new Error(`Timed out waiting for approval with validation ${validation}`);
+}
+
 function attachedTransitionWorkflow(): WorkflowDefinition {
   let attempts = 0;
   return {
@@ -217,6 +252,38 @@ describe("runner API", () => {
 
     expect(store.approve("review")).toEqual({ ok: true, stepKey: "review" });
     await expect(pending).resolves.toEqual({ decision: "approved" });
+  });
+
+  it("lets approve and resume resolve pending approvals with validation mode none", async () => {
+    const runId = "run-none-validation-store";
+    const workflow = noneValidationYieldWorkflow();
+    const store = new RunnerSessionStore({ runId, workflow, objective: workflow.title, objectives: [] });
+
+    const approvePending = store.waitForDecision({ stepKey: "handoff", reason: "confirmation", validation: "none" });
+    expect(store.approve("handoff")).toEqual({ ok: true, stepKey: "handoff" });
+    await expect(approvePending).resolves.toEqual({ decision: "approved" });
+
+    const resumePending = store.waitForDecision({ stepKey: "handoff", reason: "confirmation", validation: "none" });
+    expect(store.resume("handoff")).toEqual({ ok: true, stepKey: "handoff" });
+    await expect(resumePending).resolves.toEqual({ decision: "approved" });
+  });
+
+  it("does not deadlock a run whose yielding step has validation mode none", async () => {
+    const runId = "run-none-validation";
+    const workflow = noneValidationYieldWorkflow();
+    const store = new RunnerSessionStore({ runId, workflow, objective: workflow.title, objectives: [] });
+
+    const runPromise = runWorkflow(workflow, { runId, observer: store, controller: store });
+
+    await waitForApprovalValidation(store, "none");
+    expect(store.approve("handoff").ok).toBe(true);
+
+    await waitForApprovalValidation(store, "external");
+    expect(store.resume("handoff").ok).toBe(true);
+
+    const result = await runPromise;
+    expect(result.status).toBe("succeeded");
+    expect(result.stepRuns[0]?.status).toBe("succeeded");
   });
 
   it("serves authenticated snapshots, details, and SSE events while a run is active", async () => {


### PR DESCRIPTION
## Summary

Fixes two runner bugs found during a code review of `src/`, both confirmed with live repros before fixing:

### 1. Approval deadlock for steps with validation mode `none`

A task step with `validation: { mode: "none", autoConfirm: false }` whose executor yields (`YIELD_EXTERNAL`) entered a wait that could never be released:

- `resolvePendingApproval` required the pending validation to be exactly `human` for approve and `external` for resume, so both `wfm approve` and `wfm resume` returned 409 forever (`Cannot approve none validation for s1` / `Cannot resume none validation for s1`). Only cancel worked.
- Worse in the interactive CLI: the terminal prompt handler discarded the `{ok: false}` result, so typing `a` closed the prompt and left `wfm run` hung with no feedback.

**Fix:** waits whose validation is `none`/unset can now be released by either approve or resume (strict matching is unchanged for explicit `human`/`external` modes), and the CLI prompt reports a rejected decision to stderr instead of swallowing it.

### 2. pi-agent executor reused stale `output.json` as a false SUCCESS

The executor never cleared `outputPath` before spawning. With a fixed `payload.runDir` (or any retry reusing the directory), an agent that exited 0 without writing output got the **previous attempt's** envelope reported as this attempt's result:

```
attempt 1: SUCCESS "ATTEMPT_1_DATA"
attempt 2: SUCCESS "ATTEMPT_1_DATA"   (agent wrote no output file!)
```

**Fix:** remove any leftover `output.json` during setup, so this case now fails with `PI Agent output file not found` as intended.

## Tests

- `tests/runnerApi.test.ts`: store-level test that approve and resume both resolve `none`-validation waits, plus an end-to-end test running the exact deadlock workflow through `runWorkflow` to `succeeded`.
- `tests/piAgentExecutor.test.ts`: regression test that a second attempt in a reused runDir whose agent writes no output fails instead of returning the stale attempt-1 payload.
- `bun run test:unit`: 156 pass, 0 fail. Biome lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)