### PR TITLE
ci(release): auto-merge release PRs and stay pre-1.0

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,5 +28,19 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Auto-merge release PR
+        if: steps.release.outputs.prs_created == 'true'
+        run: |
+          PR_NUMBER=$(echo "$RELEASE_PR" | jq -r '.number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No release PR number in output; skipping auto-merge."
+            exit 0
+          fi
+          gh pr merge --squash --auto "$PR_NUMBER" --repo "$GITHUB_REPOSITORY"
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          RELEASE_PR: ${{ steps.release.outputs.pr }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,8 @@
     ".": {
       "release-type": "node",
       "package-name": "@workflow-manager/runner",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true
     }
   },
   "include-v-in-tag": true


### PR DESCRIPTION
## Summary

- Wire the existing `RELEASE_PLEASE_TOKEN` PAT into `release-please.yml` — the action was falling back to `GITHUB_TOKEN`, which this repo blocks from creating PRs, so every Release Please run failed at the final step and no release PR was ever opened.
- Auto-merge the release PR (`gh pr merge --squash --auto`) once PR checks pass, so a release happens automatically as part of merging a change — no manual release-PR step.
- Add `bump-minor-pre-major` so the pending `feat!` pi-adapter change releases as **0.3.0** instead of 1.0.0 while the package is pre-adoption.

## Why

`npm view @workflow-manager/runner version` is stuck at 0.2.0: Release Please failed on every main push ("GitHub Actions is not permitted to create or approve pull requests"), so `npm-publish.yml` always hit its skip-duplicate path. The PAT secret existed since May but was never referenced by the workflow.

## How

Using the PAT (not `GITHUB_TOKEN`) also matters downstream: pushes and tags created by the PAT trigger `npm-publish.yml` and `release.yml`, which `GITHUB_TOKEN` events never would. Repo settings were also updated (allow auto-merge; allow Actions to create PRs as fallback).

## Validation

- `bun run lint` ✅ / `bun run build` ✅ (no TS changes; CI config only)
- End-to-end verification happens on merge: this PR touches `release-please-config.json`, which is in the Release Please path filter, so the chain fires immediately → release PR 0.3.0 auto-merges → tag `v0.3.0` + GitHub release + npm publish.

## Docs

No user-visible CLI behavior changed; release flow is documented in README "Release" section and still accurate (merging the release PR publishes — it now merges itself).

## Risk / rollout

If `RELEASE_PLEASE_TOKEN` is expired the run fails at auth; refresh the PAT (contents + pull-requests write). Auto-merge waits for PR checks, so a red release PR will not merge silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)