### PR TITLE
ci(release): tag releases as vX.Y.Z without component prefix

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,8 @@
       "release-type": "node",
       "package-name": "@workflow-manager/runner",
       "changelog-path": "CHANGELOG.md",
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "include-component-in-tag": false
     }
   },
   "include-v-in-tag": true


### PR DESCRIPTION
## Summary

- Add `include-component-in-tag: false` so release-please tags `v0.4.0` instead of `runner-v0.4.0` going forward.

## Why

`release.yml` (binary build + installer assets) triggers on `v*` tags only. The 0.3.0 release was tagged `runner-v0.3.0`, so no binaries were built and the latest release had no installer asset, breaking the curl installer.

## Validation

- `bun run lint` ✅ (config-only change)
- The 0.3.0 tag itself is remediated separately by pushing `v0.3.0` manually to trigger the binary build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)