### PR TITLE
chore(pkg): add repository metadata required for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@workflow-manager/runner",
   "version": "0.3.0",
   "description": "CLI runner for in-memory and markdown workflow orchestration using ATEP-like envelopes",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/navio/workflow-manager.git"
+  },
   "type": "module",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary

- Add `repository.url` to `package.json` — `npm publish --provenance` rejects the package with E422 because the sigstore provenance bundle's source repository (`https://github.com/navio/workflow-manager`) cannot be matched against an empty `repository.url`.

## Why

This is the last blocker for publishing 0.3.0: token auth now works, but provenance verification fails on the missing field. Merging this triggers `npm-publish.yml` (package.json is in its path filter), which will publish 0.3.0.

## Validation

- `bun run lint` ✅ / `bun run build` ✅ / `npm pack --dry-run` ✅ (52 files, same as before)
- `chore:` commit type, so release-please will not cut an extra version for this metadata change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)