### PR TITLE
ci(release): publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,6 +10,7 @@ on:
       - "src/**"
       - "skills/**"
       - "man/**"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -32,8 +33,10 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org
+          node-version: 24
+
+      - name: Update npm for trusted publishing
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -60,8 +63,6 @@ jobs:
       - name: Publish to npm
         if: steps.version_check.outputs.should_publish == 'true'
         run: npm publish --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Skip duplicate publish
         if: steps.version_check.outputs.should_publish != 'true'


### PR DESCRIPTION
## Summary

- Authenticate `npm publish` with the GitHub Actions OIDC token instead of `NPM_TOKEN` — the package owner configured a trusted publisher on npmjs.com for `navio/workflow-manager` / `npm-publish.yml`.
- Run Node 24 and update npm (trusted publishing requires npm ≥ 11.5.1; Node 22 bundles npm 10).
- Drop `registry-url` from setup-node so the generated `.npmrc` doesn't reference an unset `NODE_AUTH_TOKEN` env var (npm errors on missing env in config).
- Add `workflow_dispatch` so the publish can be re-triggered manually.

## Why

No more expiring npm tokens — the publish failures this week were all token lifecycle issues (E404 expired, EOTP wrong token type). OIDC removes the credential entirely; provenance continues to work and is enforced by `--provenance`.

## Validation

- `bun run lint` ✅ (CI config only)
- Real OIDC exercise happens on the next release publish; `workflow_dispatch` allows a manual smoke run (it will take the skip-duplicate path at the current version, validating setup without publishing).

## Risk / rollout

If OIDC fails on the next release, rerunning after re-adding `NODE_AUTH_TOKEN` env restores the old path; the `NPM_TOKEN` secret remains in the repo until the first successful OIDC publish, then can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)