### PR TITLE
feat(cli)!: replace wfm agent with wfm skill install

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The core ideas:
 - **The envelope protocol.** Every step execution returns a structured result: an execution status (`SUCCESS`, `FAILED`, `QA_REJECTED`, `YIELD_EXTERNAL`) plus a QA routing action (`PROCEED`, `RETRY_CURRENT`, `ROLLBACK_PREVIOUS`, `RESTART_ALL`). That's what lets the engine retry a step, roll back to the previous one, or restart the whole run based on what the agent reported.
 - **Human-in-the-loop control.** While a run is active, wfm starts a local HTTP attach API (token-protected, with SSE event streaming), so a waiting step can be resolved either in the terminal prompt or from another shell with `wfm approve` / `wfm resume` / `wfm cancel`.
 - **A registry.** `wfm publish` / `pull` / `search` / `auth` talk to a Supabase-backed remote registry (the `apps/remote-registry` web app in this repo) for sharing workflows, with skills bundled and SHA-256 verified. Runs also emit opt-in telemetry there.
-- **Supporting commands.** `wfm scaffold` writes a starter workflow, `wfm validate` checks the schema and dependency cycles, `wfm doctor` verifies the host has the needed CLIs and API keys before a run, `wfm agent` drops an AGENTS.md rules file, and `wfm man` shows the man page.
+- **Supporting commands.** `wfm scaffold` writes a starter workflow, `wfm validate` checks the schema and dependency cycles, `wfm doctor` verifies the host has the needed CLIs and API keys before a run, `wfm skill install` installs the bundled agent skills into Claude Code or opencode skill directories, and `wfm man` shows the man page.
 
 Install the latest prebuilt CLI with:
 
@@ -31,7 +31,7 @@ If `wfm` is not available immediately in the same terminal, run the shell reload
 
 ## Architecture
 
-- `src/index.ts`: CLI commands (`doctor`, `agent`, `scaffold`, `validate`, `run`)
+- `src/index.ts`: CLI commands (`doctor`, `skill`, `scaffold`, `validate`, `run`)
 - `src/parser.ts`: parsing + validation
 - `src/engine.ts`: execution loop, confirmations, retries, rollback/restart
 - `src/piAgentExecutor.ts`: default executor driving the `pi` coding agent CLI
@@ -51,7 +51,7 @@ bun run build
 bun link
 
 wfm doctor
-wfm agent ./AGENTS.md
+wfm skill install
 wfm scaffold ./example-workflow.md
 wfm validate ./example-workflow.md
 wfm doctor ./example-workflow.md
@@ -214,10 +214,11 @@ Manual help:
 wfm man
 ```
 
-Agent rules:
+Agent skills:
 
 ```bash
-wfm agent ./AGENTS.md
+wfm skill list
+wfm skill install
 ```
 
 Remote registry commands:
@@ -230,13 +231,20 @@ wfm remote info alice/remote-bunny
 
 ## Agent skills
 
-The published `@workflow-manager/runner` npm package now ships the CLI runner and the bundled agent skills together.
+The published `@workflow-manager/runner` npm package ships the CLI runner and the bundled agent skills together. The primary skill is `skills/workflow-manager-cli/SKILL.md`, which teaches an agent how to configure, author, run, and publish workflows with `wfm`.
 
-- bundled skill: `skills/workflow-manager-cli/SKILL.md`
-- discovery keyword: `tanstack-intent`
-- install flow: install `@workflow-manager/runner`, then run `npx @tanstack/intent@latest list` and `npx @tanstack/intent@latest install`
+Install skills with the CLI:
 
-Example usage:
+```bash
+wfm skill list                       # show bundled skills
+wfm skill install                    # workflow-manager-cli -> ./.claude/skills/
+wfm skill install --global           # -> ~/.claude/skills/
+wfm skill install --agent opencode   # -> ./.opencode/skill/
+wfm skill install --all              # install every bundled skill
+wfm skill install doc-sync --dir ./my/skills
+```
+
+TanStack Intent discovery is also supported (package keyword `tanstack-intent`):
 
 ```bash
 npm install @workflow-manager/runner

--- a/doc/guide/getting-started.md
+++ b/doc/guide/getting-started.md
@@ -29,7 +29,8 @@ wfm --help
 
 ```bash
 wfm doctor
-wfm agent ./AGENTS.md
+wfm skill list
+wfm skill install
 wfm scaffold ./example-workflow.md
 wfm validate ./example-workflow.md
 wfm doctor ./example-workflow.md
@@ -55,7 +56,7 @@ wfm pull alice/remote-bunny --output ./remote-bunny.json
 ## Typical workflow
 
 1. Run `wfm doctor` to inspect host adapter and key setup.
-2. Run `wfm agent ./AGENTS.md` when you want local agent rules for using WFM safely.
+2. Run `wfm skill install` when an agent (Claude Code, opencode) should load WFM usage guidance on demand; `--global` installs for all projects.
 3. Run `wfm scaffold ./example-workflow.md` to generate a starter file.
 4. Edit frontmatter (Markdown) or JSON fields with your steps, dependencies, validation, and adapter init config.
 5. Run `wfm validate ./example-workflow.md` or `wfm validate ./example-workflow.json` until validation passes.

--- a/man/wfm.1
+++ b/man/wfm.1
@@ -15,8 +15,11 @@ Workflow files can be Markdown with YAML frontmatter or JSON.
 .B doctor [workflow.md|workflow.json] [--json]
 Inspect host adapter setup, LLM access keys, and current adapter implementation status. When a workflow path is provided, also validate schema and runtime requirements without executing steps.
 .TP
-.B agent [path] [--force]
-Create WFM-focused agent rules. The default path is ./AGENTS.md. Existing files are not overwritten unless --force is passed.
+.B skill list
+List the agent skills bundled with the npm package.
+.TP
+.B skill install [name ...] [--agent claude|opencode] [--global] [--dir path] [--all] [--force]
+Install bundled agent skills into an agent skill directory. Defaults to the workflow-manager-cli skill and the project-level Claude Code directory (./.claude/skills). Existing skills are not overwritten unless --force is passed.
 .TP
 .B scaffold [path] [--format markdown|json]
 Create a starter workflow file. Format defaults to markdown unless the output
@@ -128,8 +131,11 @@ Inspect host setup:
 Check a workflow before running it:
 .B wfm doctor ./example-workflow.json
 .TP
-Create agent rules:
-.B wfm agent ./AGENTS.md
+Install the bundled CLI skill for Claude Code:
+.B wfm skill install
+.TP
+Install every bundled skill globally:
+.B wfm skill install --all --global
 .SH FILES
 .TP
 .B man/wfm.1

--- a/skills/README.md
+++ b/skills/README.md
@@ -18,7 +18,21 @@ Install the main package in the project where you want the CLI and skill availab
 npm install @workflow-manager/runner
 ```
 
-Then use TanStack Intent to discover and map the shipped skill into your agent configuration:
+Then install bundled skills into an agent's skill directory with the CLI:
+
+```bash
+wfm skill list                       # list bundled skills
+wfm skill install                    # workflow-manager-cli -> ./.claude/skills/
+wfm skill install --global           # -> ~/.claude/skills/
+wfm skill install --agent opencode   # -> ./.opencode/skill/
+wfm skill install --all              # install every bundled skill
+wfm skill install <name> --dir path  # install into any directory
+```
+
+`wfm skill install` copies the skill directory (`SKILL.md` plus any assets) into the
+target so the agent loads it on demand; pass `--force` to overwrite an existing install.
+
+Alternatively, use TanStack Intent to discover and map the shipped skills into your agent configuration:
 
 ```bash
 npx @tanstack/intent@latest list

--- a/skills/workflow-manager-cli/SKILL.md
+++ b/skills/workflow-manager-cli/SKILL.md
@@ -1,116 +1,181 @@
 ---
-name: @workflow-manager/runner/cli
+name: workflow-manager-cli
 description: >
-  Load this skill when working with the wfm CLI from @workflow-manager/runner, authoring or
-  validating workflow definitions, configuring step skills and adapters, or
-  publishing workflows to the remote registry. Covers doctor, agent, scaffold,
-  validate, run, auth, publish, pull, search, and remote info.
+  Load this skill when working with the wfm CLI from @workflow-manager/runner:
+  authoring, validating, or running workflow definitions, configuring adapters
+  and step skills, controlling runs through the attach API, or publishing
+  workflows to the remote registry. Covers doctor, skill, scaffold, validate,
+  run, approve, resume, cancel, auth, publish, pull, search, and remote info.
 type: core
-library: @workflow-manager/runner
-library_version: "0.1.0"
+library: "@workflow-manager/runner"
 sources:
   - "navio/workflow-manager:README.md"
   - "navio/workflow-manager:src/index.ts"
   - "navio/workflow-manager:src/parser.ts"
   - "navio/workflow-manager:src/engine.ts"
+  - "navio/workflow-manager:src/runtimePreflight.ts"
+  - "navio/workflow-manager:src/skillResolver.ts"
   - "navio/workflow-manager:src/remote/commands.ts"
+  - "navio/workflow-manager:doc/guide/runner-api.md"
 ---
 
 # wfm CLI
 
-Use this skill when you need to create or operate `workflow-manager` workflows from the terminal with `wfm`.
+`wfm` (also installed as `workflow-manager`) parses a workflow definition file (Markdown frontmatter or JSON), validates it, and executes its steps through pluggable agent adapters with deterministic dependency ordering, approvals, retries, and rollback routing.
 
-## When to use this skill
+## Core flow
 
-Use it when the user wants to:
+Follow this sequence unless the user asks for a narrower task:
 
-- scaffold a new workflow definition
-- create local agent rules for WFM usage
-- validate or run a workflow file
-- configure approvals, retry policy, or adapter initialization
-- publish a workflow to the remote registry
-- search for or pull a shared workflow
-- understand the difference between Markdown and JSON workflow formats
+1. `wfm doctor` — inspect host adapter binaries and provider API keys.
+2. `wfm scaffold ./workflow.md` (or `--format json`) — generate a starter definition.
+3. Edit step keys, objectives, `dependsOn`, validation modes, and `taskSpec.init`.
+4. `wfm validate ./workflow.md` — always validate before running or publishing.
+5. `wfm doctor ./workflow.md` — preflight the specific workflow before real adapter runs.
+6. `wfm run ./workflow.md` — execute with live progress; add `--verbose` for agent output.
+7. `wfm publish ./workflow.md` — only after validation succeeds.
 
-## Core workflow
-
-Use this sequence unless the user asks for a narrower task:
-
-1. Inspect local setup with `wfm doctor`
-2. Create project agent rules with `wfm agent` when local agent guidance is useful
-3. Scaffold a starter file with `wfm scaffold`
-4. Edit the workflow definition
-5. Validate the file with `wfm validate`
-6. Execute it with `wfm run`
-7. If needed, authenticate and publish with the remote registry commands
-
-## Local workflow commands
+## Command reference
 
 ```bash
-wfm doctor
-wfm agent ./AGENTS.md
-
-wfm scaffold ./example-workflow.md
-wfm scaffold ./example-workflow.json --format json
-
-wfm validate ./example-workflow.md
-wfm validate ./example-workflow.json
-
-wfm run ./example-workflow.md --confirm discover,qa_gate:human
-wfm run ./example-workflow.json --auto-confirm-all
+wfm doctor [workflow] [--json]        # host + per-workflow preflight checks
+wfm skill list                        # list skills bundled with the npm package
+wfm skill install [name ...]          # install bundled skills for an agent (see below)
+wfm scaffold [path] [--format markdown|json]
+wfm validate <workflow>
+wfm run <workflow> [--input input.json] [--objective "text"] [--confirm stepA,stepB:human] [--auto-confirm-all] [--port 43121] [--verbose] [--json]
+wfm approve|resume|cancel [--url ...] [--token ...] [--run-id ...] [--step ...] [--actor ...] [--note ...]
+wfm auth <login|whoami|logout> [--token <token>]
+wfm publish <workflow> [--slug s] [--title t] [--description d] [--visibility public|private] [--version v] [--tag a,b] [--draft]
+wfm pull <owner/slug> [--version v] [--output path]
+wfm search [query]
+wfm remote info <owner/slug>
+wfm man
 ```
 
-## Remote registry commands
+Exit codes: `0` success, `1` validation or runtime error, `2` run finished in a non-success terminal status.
+
+## Host configuration
+
+Adapters (set per step via `taskSpec.adapterKey`; omit for the default):
+
+| Adapter | Kind | Notes |
+| --- | --- | --- |
+| `pi-agent` | real (default) | Drives the host `pi` coding agent CLI in print mode. `pi` must be on `PATH`; its auth lives in `~/.pi`, not env vars. |
+| `opencode` | real (opt-in) | Requires the `opencode` CLI on `PATH`. |
+| `claude-code` | real (opt-in) | Requires the `claude` CLI on `PATH`. |
+| `codex` | mock-routed | Deterministic simulation. |
+| `mock` | mock | Deterministic simulation for tests and examples. |
+
+Provider API keys are inferred from `taskSpec.init.model` and checked by `wfm doctor` / run preflight:
+
+- `openrouter/...` → `OPENROUTER_API_KEY`
+- `openai/...`, `gpt-...` → `OPENAI_API_KEY`
+- `anthropic/...`, `claude-...` → `ANTHROPIC_API_KEY`
+
+Steps can also declare extra required env vars in `taskSpec.payload.requiredEnv`.
+
+For custom `pi-agent` commands, the run directory exposes `input.json` / `output.json` envelopes through the `WFM_PI_INPUT_FILE` and `WFM_PI_OUTPUT_FILE` env vars.
+
+## Workflow anatomy
+
+Both formats describe the same schema; Markdown holds it in YAML frontmatter (body text is free-form notes), JSON holds it directly. Required top-level fields: `key`, `title`, `steps`. Optional: `description`, `objectives`, `inputSchema`, `outputSchema`, `defaultRetryPolicy`, `skills`.
+
+```yaml
+---
+key: my-workflow                # stable external identifier — change cautiously
+title: My Workflow
+objectives: [deliver a working implementation]
+defaultRetryPolicy:
+  maxAttempts: 2
+steps:
+  - key: discover               # stable step key
+    kind: task                  # task | approval
+    objective: Understand requirements and constraints
+    dependsOn: []
+    validation:                 # mode: none | human | external
+      mode: human
+      required: true
+      autoConfirm: false
+    taskSpec:
+      # adapterKey omitted -> pi-agent
+      init:
+        context: { repo: example/repo }
+        skills: [architecture, planning]      # resolved step skills, see below
+        mcps: [mcp://github]
+        systemPrompts: [Focus on architecture trade-offs]
+        model: openrouter/anthropic/claude-sonnet-4
+      payload: {}
+  - key: qa_gate
+    kind: approval              # human checkpoint, no adapter
+    dependsOn: [discover]
+    approvalSpec:
+      autoApprove: false
+      validation: { mode: human, required: true, autoConfirm: false }
+---
+```
+
+Authoring rules:
+
+- Workflow keys, step keys, and status strings are stable external identifiers; prefer additive, backward-compatible changes.
+- Make `dependsOn` explicit; the engine resolves dependencies deterministically and rejects cycles.
+- Keep validation modes explicit per step. `human` pauses for approval (inline terminal prompt or attach API); `external` expects an outside system to resume the run.
+- Use `adapterKey: mock` for deterministic examples and tests; use Markdown when humans will review notes, JSON for machine-generated definitions.
+
+Steps communicate via ATEP-like envelopes: an `InputEnvelope` (global/step context plus priming config) goes in, an `OutputEnvelope` comes out carrying execution status and a QA routing action — `PROCEED`, `RETRY_CURRENT`, `ROLLBACK_PREVIOUS`, or `RESTART_ALL` — which the engine uses to advance, retry, roll back, or restart the run.
+
+## Step skills
+
+`taskSpec.init.skills` names are resolved per step in this order:
+
+1. Embedded `skills.<name>.content` in the workflow file (how published workflows ship skills).
+2. `skills.<name>.source` — a relative path that must match `skills/**/SKILL.md` under the workflow directory.
+3. `<workflow-dir>/skills/<name>/SKILL.md` (project-local).
+4. `~/.workflow-manager/skills/<name>/SKILL.md` (user-global).
+5. The npm-packaged skills under `node_modules`.
+
+`wfm publish` inlines resolved skill markdown into `skills[*].content` with a `contentSha256` integrity hash; pulled workflows are rejected when declared skill content is missing or tampered.
+
+## Running and controlling runs
+
+`wfm run` shows live progress on stderr and starts a local attach API on `127.0.0.1` for the lifetime of the run (OS-assigned port, or `--port`). The base URL and a per-run bearer token are printed to stderr before execution starts; every endpoint except `/health` requires `Authorization: Bearer <token>`. The API serves the session (`/session`), run snapshots, per-step detail, logs, an SSE event stream, and approve/resume/cancel endpoints (contract: `doc/guide/runner-api.md`).
+
+- Interactive human approvals show an inline terminal prompt; non-interactive waits are resolved via `wfm approve` / `wfm resume` / `wfm cancel` using the printed URL and token.
+- `--confirm stepA,stepB:human` pre-supplies confirmations for specific steps.
+- Never use `--auto-confirm-all` unless the workflow is intentionally non-interactive — it bypasses every approval gate.
+- `--json` prints the final result (including a `session` object) on stdout while progress stays on stderr.
+- `--input input.json` merges a JSON file into global input state; `--objective` overrides the run objective.
+
+## Remote registry
 
 ```bash
-wfm auth login --token <token>
+wfm auth login --token <token>     # token created in the registry web app
 wfm auth whoami
-wfm auth logout
-
-wfm search bunny
-wfm remote info alice/remote-bunny
-wfm publish ./example-workflow.json --visibility public --tag storytelling,example
-wfm pull alice/remote-bunny --output ./remote-bunny.json
+wfm search <query>
+wfm remote info <owner/slug>
+wfm publish ./workflow.md --visibility public --tag automation
+wfm pull <owner/slug> --output ./pulled-workflow.json
 ```
 
-## Skill guidance
+If `publish` fails, check login state with `wfm auth whoami`. Preserve the author's source format when publishing.
 
-- Prefer `validate` before `run` or `publish`
-- Keep `runWorkflow(...)` behavior registry-agnostic; registry operations belong in the CLI remote commands
-- Use Markdown workflows when the user wants editable frontmatter plus notes
-- Use JSON workflows when the user wants machine-generated or strongly structured files
-- Use `--auto-confirm-all` only when the workflow is intentionally non-interactive
-- When publishing, preserve the source format the user authored
+## Installing these skills for agents
 
-## Workflow authoring checklist
+`wfm skill install` copies bundled skills into an agent's skill directory so the agent loads this guidance on demand:
 
-- Set stable `key` and `title` values
-- Define clear step `objective` text
-- Add `dependsOn` relationships explicitly
-- Set validation mode per step (`none`, `human`, `external`)
-- Configure adapter initialization under `taskSpec.init`
-- Use stable step keys because tests and docs may refer to them
+```bash
+wfm skill list                                   # see what ships with the package
+wfm skill install                                # workflow-manager-cli -> ./.claude/skills/
+wfm skill install --global                       # -> ~/.claude/skills/
+wfm skill install --agent opencode               # -> ./.opencode/skill/
+wfm skill install --all --force                  # every bundled skill, overwrite existing
+wfm skill install doc-sync --dir ./my/skills     # any other destination
+```
 
-## Adapter and validation notes
+## Troubleshooting
 
-- Supported adapters include default `pi-agent` plus explicit `mock`, `opencode`, `codex`, and `claude-code`
-- Omit `taskSpec.adapterKey` to run a task with the `pi` coding agent CLI
-- Put skills, MCP endpoints, system prompts, model, and context under `taskSpec.init`
-- Human approvals should stay explicit in workflow definitions
-- External validation should be deterministic where possible
-- Use the mock adapter for fast tests and scaffolding flows
-
-## Recommended project references
-
-- `src/index.ts`: CLI command entrypoint
-- `src/parser.ts`: Markdown and JSON parsing plus validation
-- `src/engine.ts`: orchestration loop
-- `src/remote/commands.ts`: auth, publish, pull, search, and remote info commands
-- `tests/`: unit and e2e coverage for workflow behavior
-
-## Typical troubleshooting
-
-- If validation fails, inspect the reported schema or dependency error before running again
-- If `publish` fails, confirm the user is logged in with `wfm auth whoami`
-- If remote calls fail in the browser, verify the remote registry app has valid Supabase `VITE_*` environment variables
-- If a real adapter test fails, confirm the underlying external CLI is installed and available on `PATH`
+- Validation failure: fix the reported schema or dependency-cycle error before re-running; ordinary input errors are reported as messages, not stack traces.
+- `doctor` failure for a real adapter: install the missing CLI (`pi`, `opencode`, `claude`) or export the missing provider API key.
+- Run stuck `waiting_for_approval`: approve inline in the terminal, or use `wfm approve` with the attach URL/token printed at run start.
+- Non-zero exit `2`: the run completed but not successfully — re-run with `--json` or `--verbose` to inspect step output.
+- Publish/pull failures: verify `wfm auth whoami`; for skill integrity errors, confirm the declared skill files exist and match their `contentSha256`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import matter from "gray-matter";
 import { CliRunRenderer } from "./cliRunRenderer.js";
 import { startRunnerApiServer } from "./runnerApi.js";
 import { RunnerSessionStore } from "./runnerSession.js";
@@ -33,7 +34,8 @@ function usage(): void {
   const cli = cliDisplayName();
   console.log(`${cli} commands:
   doctor [workflow.md|workflow.json] [--json]
-  agent [path] [--force]
+  skill list
+  skill install [name ...] [--agent claude|opencode] [--global] [--dir path] [--all] [--force]
   scaffold [path] [--format markdown|json]
   validate <workflow.md|workflow.json>
   run <workflow.md|workflow.json> [--input input.json] [--objective "string"] [--confirm stepA,stepB:human] [--auto-confirm-all] [--port 43121] [--verbose] [--json]
@@ -262,37 +264,6 @@ steps:
 Edit frontmatter to configure orchestration behavior.
 `;
 
-const AGENT_RULES_TEMPLATE = `# WFM Agent Rules
-
-Use these rules when creating, validating, running, or publishing workflow-manager workflows with the \`wfm\` CLI.
-
-## Core Flow
-
-1. Start with \`wfm doctor\` to inspect local adapter and API key setup.
-2. Create a starter workflow with \`wfm scaffold ./workflow.md\` or \`wfm scaffold ./workflow.json --format json\`.
-3. Edit stable workflow keys, step objectives, dependencies, validation modes, and adapter initialization.
-4. Run \`wfm validate <workflow>\` before every run or publish.
-5. Run \`wfm doctor <workflow>\` before using real host-backed adapters.
-6. Run with \`wfm run <workflow>\`; use \`--verbose\` when agent logs are needed.
-7. Publish only after validation succeeds with \`wfm publish <workflow>\`.
-
-## Workflow Authoring
-
-- Keep workflow, step, and adapter keys stable; external tools and tests may reference them.
-- Omit \`taskSpec.adapterKey\` for the default \`pi-agent\` adapter.
-- Use \`adapterKey: mock\` for deterministic tests and examples.
-- Put skills, MCP endpoints, system prompts, model, and context under \`taskSpec.init\`.
-- Model-backed steps should declare required environment variables through provider-specific model names or \`taskSpec.payload.requiredEnv\`.
-- Human or external validation should be explicit in the workflow file.
-
-## Running Safely
-
-- Do not use \`--auto-confirm-all\` unless the workflow is intentionally non-interactive.
-- Prefer \`wfm doctor <workflow>\` before runs that use \`pi-agent\`, real \`opencode\`, or real \`claude-code\`.
-- Use the attach API output from \`wfm run\` for approval, resume, and cancel commands.
-- Preserve Markdown workflows when humans will review notes; use JSON for generated or machine-edited workflows.
-`;
-
 function resolveScaffoldFormat(targetPath: string, explicitFormat?: string): "markdown" | "json" {
   if (explicitFormat === "markdown" || explicitFormat === "json") {
     return explicitFormat;
@@ -322,34 +293,178 @@ function parseScaffoldArgs(args: string[]): { targetPath?: string; format?: stri
   return { targetPath, format };
 }
 
-function parseAgentArgs(args: string[]): { targetPath?: string; force: boolean } {
-  let targetPath: string | undefined;
-  let force = false;
+const DEFAULT_INSTALL_SKILL = "workflow-manager-cli";
 
-  for (const arg of args) {
-    if (arg === "--force" || arg === "-f") {
-      force = true;
-      continue;
-    }
+const SKILL_INSTALL_TARGETS: Record<string, { projectDir: string; globalDir: string }> = {
+  claude: {
+    projectDir: path.join(".claude", "skills"),
+    globalDir: path.join(os.homedir(), ".claude", "skills"),
+  },
+  opencode: {
+    projectDir: path.join(".opencode", "skill"),
+    globalDir: path.join(os.homedir(), ".config", "opencode", "skill"),
+  },
+};
 
-    if (!arg.startsWith("-") && !targetPath) {
-      targetPath = arg;
-    }
-  }
-
-  return { targetPath, force };
+interface PackagedSkill {
+  name: string;
+  dir: string;
+  description: string;
 }
 
-function cmdAgent(targetPath?: string, force = false): number {
-  const resolvedPath = path.resolve(targetPath ?? "./AGENTS.md");
-  if (fs.existsSync(resolvedPath) && !force) {
-    console.error(`Agent rules already exist at ${resolvedPath}. Pass --force to overwrite.`);
+function packagedSkillsDir(): string {
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "skills");
+}
+
+function listPackagedSkills(): PackagedSkill[] {
+  const root = packagedSkillsDir();
+  if (!fs.existsSync(root)) {
+    return [];
+  }
+
+  const skills: PackagedSkill[] = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const dir = path.join(root, entry.name);
+    const skillFile = path.join(dir, "SKILL.md");
+    if (!fs.existsSync(skillFile)) continue;
+
+    let description = "";
+    try {
+      const parsed = matter(fs.readFileSync(skillFile, "utf-8"));
+      if (typeof parsed.data.description === "string") {
+        description = parsed.data.description.replace(/\s+/g, " ").trim();
+      }
+    } catch {
+      // skills without parseable frontmatter are still installable
+    }
+
+    skills.push({ name: entry.name, dir, description });
+  }
+
+  return skills;
+}
+
+function cmdSkillList(): number {
+  const skills = listPackagedSkills();
+  if (skills.length === 0) {
+    console.error(`No bundled skills found at ${packagedSkillsDir()}.`);
     return 1;
   }
 
-  fs.mkdirSync(path.dirname(resolvedPath), { recursive: true });
-  fs.writeFileSync(resolvedPath, AGENT_RULES_TEMPLATE, "utf-8");
-  console.log(`Wrote WFM agent rules: ${resolvedPath}`);
+  console.log("Bundled skills:\n");
+  for (const skill of skills) {
+    console.log(`  ${skill.name}`);
+    if (skill.description) {
+      console.log(`      ${skill.description}`);
+    }
+  }
+  console.log(`\nInstall with: ${cliDisplayName()} skill install <name> [--agent claude|opencode] [--global]`);
+  return 0;
+}
+
+interface SkillInstallArgs {
+  names: string[];
+  agent: string;
+  global: boolean;
+  dir?: string;
+  force: boolean;
+  all: boolean;
+}
+
+function parseSkillInstallArgs(args: string[]): SkillInstallArgs {
+  const parsed: SkillInstallArgs = { names: [], agent: "claude", global: false, force: false, all: false };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+
+    if (arg === "--agent") {
+      parsed.agent = args[i + 1] ?? "";
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--dir") {
+      parsed.dir = args[i + 1];
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--global" || arg === "-g") {
+      parsed.global = true;
+      continue;
+    }
+
+    if (arg === "--force" || arg === "-f") {
+      parsed.force = true;
+      continue;
+    }
+
+    if (arg === "--all") {
+      parsed.all = true;
+      continue;
+    }
+
+    if (!arg.startsWith("-")) {
+      parsed.names.push(arg);
+    }
+  }
+
+  return parsed;
+}
+
+function resolveSkillInstallRoot(args: SkillInstallArgs): string | undefined {
+  if (args.dir) {
+    return path.resolve(args.dir);
+  }
+
+  const target = SKILL_INSTALL_TARGETS[args.agent];
+  if (!target) {
+    return undefined;
+  }
+
+  return args.global ? target.globalDir : path.resolve(target.projectDir);
+}
+
+function cmdSkillInstall(args: string[]): number {
+  const parsed = parseSkillInstallArgs(args);
+  const targetRoot = resolveSkillInstallRoot(parsed);
+  if (!targetRoot) {
+    console.error(
+      `Unknown --agent value: ${parsed.agent}. Supported agents: ${Object.keys(SKILL_INSTALL_TARGETS).join(", ")}. Use --dir for any other destination.`
+    );
+    return 1;
+  }
+
+  const available = listPackagedSkills();
+  const names = parsed.all
+    ? available.map((skill) => skill.name)
+    : parsed.names.length > 0
+      ? parsed.names
+      : [DEFAULT_INSTALL_SKILL];
+
+  for (const name of names) {
+    const skill = available.find((candidate) => candidate.name === name);
+    if (!skill) {
+      console.error(`Unknown skill: ${name}. Run \`${cliDisplayName()} skill list\` to see bundled skills.`);
+      return 1;
+    }
+
+    const destDir = path.join(targetRoot, name);
+    const destFile = path.join(destDir, "SKILL.md");
+    if (fs.existsSync(destFile) && !parsed.force) {
+      console.error(`Skill already installed at ${destFile}. Pass --force to overwrite.`);
+      return 1;
+    }
+
+    fs.mkdirSync(destDir, { recursive: true });
+    for (const entry of fs.readdirSync(skill.dir, { withFileTypes: true })) {
+      if (!entry.isFile() || entry.name === "README.md") continue;
+      fs.copyFileSync(path.join(skill.dir, entry.name), path.join(destDir, entry.name));
+    }
+    console.log(`Installed skill ${name} -> ${destDir}`);
+  }
+
   return 0;
 }
 
@@ -754,9 +869,16 @@ async function main(): Promise<void> {
     process.exit(cmdDoctor(process.argv.slice(3)));
   }
 
-  if (cmd === "agent") {
-    const { targetPath, force } = parseAgentArgs(process.argv.slice(3));
-    process.exit(cmdAgent(targetPath, force));
+  if (cmd === "skill") {
+    const sub = process.argv[3];
+    if (sub === "list") {
+      process.exit(cmdSkillList());
+    }
+    if (sub === "install") {
+      process.exit(cmdSkillInstall(process.argv.slice(4)));
+    }
+    usage();
+    process.exit(1);
   }
 
   if (cmd === "scaffold") {

--- a/src/manPage.ts
+++ b/src/manPage.ts
@@ -15,8 +15,11 @@ Workflow files can be Markdown with YAML frontmatter or JSON.
 .B doctor [workflow.md|workflow.json] [--json]
 Inspect host adapter setup, LLM access keys, and current adapter implementation status. When a workflow path is provided, also validate schema and runtime requirements without executing steps.
 .TP
-.B agent [path] [--force]
-Create WFM-focused agent rules. The default path is ./AGENTS.md. Existing files are not overwritten unless --force is passed.
+.B skill list
+List the agent skills bundled with the npm package.
+.TP
+.B skill install [name ...] [--agent claude|opencode] [--global] [--dir path] [--all] [--force]
+Install bundled agent skills into an agent skill directory. Defaults to the workflow-manager-cli skill and the project-level Claude Code directory (./.claude/skills). Existing skills are not overwritten unless --force is passed.
 .TP
 .B scaffold [path] [--format markdown|json]
 Create a starter workflow file. Format defaults to markdown unless the output
@@ -128,8 +131,11 @@ Inspect host setup:
 Check a workflow before running it:
 .B wfm doctor ./example-workflow.json
 .TP
-Create agent rules:
-.B wfm agent ./AGENTS.md
+Install the bundled CLI skill for Claude Code:
+.B wfm skill install
+.TP
+Install every bundled skill globally:
+.B wfm skill install --all --global
 .SH FILES
 .TP
 .B man/wfm.1

--- a/tests/runnerCli.test.ts
+++ b/tests/runnerCli.test.ts
@@ -284,30 +284,58 @@ describe("runner CLI attach API", () => {
     expect(result.stdout).toContain("OK workflow schema and runtime requirements");
   });
 
-  it("prints agent instead of questions in usage", async () => {
+  it("prints skill commands in usage", async () => {
     const result = await runCommand(["--help"]);
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain("agent [path] [--force]");
-    expect(result.stdout).not.toContain("questions");
+    expect(result.stdout).toContain("skill list");
+    expect(result.stdout).toContain("skill install [name ...]");
+    expect(result.stdout).not.toContain("agent [path]");
   });
 
-  it("writes WFM agent rules and protects existing files", async () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wm-runner-cli-agent-"));
+  it("lists bundled skills", async () => {
+    const result = await runCommand(["skill", "list"]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("workflow-manager-cli");
+    expect(result.stdout).toContain("skill install");
+  });
+
+  it("installs the default skill for Claude Code and protects existing installs", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wm-runner-cli-skill-"));
     tempDirs.push(dir);
-    const rulesPath = path.join(dir, "AGENTS.md");
+    const installedSkill = path.join(dir, ".claude", "skills", "workflow-manager-cli", "SKILL.md");
 
-    const created = await runCommand(["agent", rulesPath]);
+    const created = await runCommand(["skill", "install"], {}, dir);
     expect(created.status).toBe(0);
-    expect(created.stdout).toContain("Wrote WFM agent rules");
-    expect(fs.readFileSync(rulesPath, "utf-8")).toContain("wfm validate <workflow>");
+    expect(created.stdout).toContain("Installed skill workflow-manager-cli");
+    const content = fs.readFileSync(installedSkill, "utf-8");
+    expect(content).toContain("name: workflow-manager-cli");
+    expect(content).toContain("wfm validate");
 
-    const blocked = await runCommand(["agent", rulesPath]);
+    const blocked = await runCommand(["skill", "install"], {}, dir);
     expect(blocked.status).toBe(1);
     expect(blocked.stderr).toContain("Pass --force to overwrite");
 
-    const forced = await runCommand(["agent", rulesPath, "--force"]);
+    const forced = await runCommand(["skill", "install", "--force"], {}, dir);
     expect(forced.status).toBe(0);
+  });
+
+  it("installs a named skill into a custom directory and rejects unknown inputs", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wm-runner-cli-skill-dir-"));
+    tempDirs.push(dir);
+
+    const installed = await runCommand(["skill", "install", "doc-sync", "--dir", dir]);
+    expect(installed.status).toBe(0);
+    expect(fs.existsSync(path.join(dir, "doc-sync", "SKILL.md"))).toBe(true);
+
+    const unknownSkill = await runCommand(["skill", "install", "no-such-skill", "--dir", dir]);
+    expect(unknownSkill.status).toBe(1);
+    expect(unknownSkill.stderr).toContain("Unknown skill: no-such-skill");
+
+    const unknownAgent = await runCommand(["skill", "install", "--agent", "unknown"]);
+    expect(unknownAgent.status).toBe(1);
+    expect(unknownAgent.stderr).toContain("Unknown --agent value");
   });
 
   it("prints the man page outside the repository root", async () => {


### PR DESCRIPTION
## Summary

Replaces the `wfm agent` command with a real skill installer. `wfm agent` wrote a static `AGENTS.md` rules template and either refused to run when `AGENTS.md` existed or clobbered it with `--force` — so in any established project it was a no-op or destructive, and it duplicated the bundled `SKILL.md` guidance with a thinner, drift-prone copy.

New commands:

- `wfm skill list` — lists the skills bundled in the npm package with their descriptions.
- `wfm skill install [name ...]` — copies a bundled skill into an agent's skill directory. Defaults to the `workflow-manager-cli` skill and Claude Code's project dir (`./.claude/skills/`). Flags: `--agent claude|opencode`, `--global`, `--dir <path>`, `--all`, `--force`.

The `workflow-manager-cli` skill is rewritten from a thin command list into a full operating guide: core flow, command reference with exit codes, host/adapter configuration (binary + auth requirements, model→API-key inference), workflow anatomy with annotated example, the ATEP envelope / QA-routing model, step-skill resolution order, attach-API run control, registry commands, and troubleshooting (~116 → ~230 lines).

Docs, man page, and CLI usage text are synced; the packaged `skills/README.md` documents the new install flow alongside TanStack Intent.

## Breaking change

The `wfm agent` command is removed. Use `wfm skill install` to install WFM usage guidance for agents instead.

## Validation

- `bun run lint` — clean
- `bun run build` — clean
- `bun test tests/runnerCli.test.ts` — 18/18 pass (two `wfm agent` tests replaced with four covering `skill list`, default install + overwrite protection, custom `--dir` install, and unknown skill/agent rejection)
- `bun run docs:build` — clean
- Manual smoke test of `wfm skill list` and `wfm skill install --dir` — both work

The only failing tests in a full `bun test` are 3 pre-existing `apps/remote-registry` local-smoke tests that need `@supabase/supabase-js` (sub-project deps not installed in a fresh worktree); unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)