### PR TITLE
fix(runner): warn instead of silently mocking claude-code/opencode

### DIFF
--- a/doc/guide/workflow-schema.md
+++ b/doc/guide/workflow-schema.md
@@ -106,3 +106,5 @@ Current adapter implementation status:
 - `opencode`: mock-routed by default; real host smoke path when `useRealAdapter` and `opencodeSmokeTest` are true
 - `codex`: currently mock-routed; real executor not implemented yet
 - `claude-code`: mock-routed by default; real host CLI path when `useRealAdapter` is true
+
+When a step explicitly sets `adapterKey: claude-code` or `adapterKey: opencode` but the opt-in flags above are not set, the step runs as a mock. `wfm doctor <workflow>` reports this under "Adapter warnings" and `wfm run` prints a warning before execution, so the fallback is never silent.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -6,7 +6,7 @@ import { executeClaudeCodeStep, shouldUseRealClaudeCode } from "./claudeCodeExec
 import { executeMockStep } from "./mockExecutor.js";
 import { executeOpencodeStep, shouldUseRealOpencode } from "./opencodeExecutor.js";
 import { executePiAgentStep } from "./piAgentExecutor.js";
-import { validateRuntimeRequirements } from "./runtimePreflight.js";
+import { adapterMockFallbackReason, validateRuntimeRequirements } from "./runtimePreflight.js";
 import type {
   ApprovalPreview,
   ApprovalDecisionPayload,
@@ -404,6 +404,11 @@ async function executeStep(
 
   if (adapterKey === "claude-code" && shouldUseRealClaudeCode(step)) {
     return executeClaudeCodeStep(step, input, attempt, workflow, workflowFilePath, hooks);
+  }
+
+  const fallbackReason = adapterMockFallbackReason(step);
+  if (fallbackReason) {
+    hooks?.onStderr?.(`[wfm] ${step.key}: ${fallbackReason}\n`);
   }
 
   return executeMockStep(step, input, attempt, hooks);

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { cmdAuth, cmdPublish, cmdPull, cmdRemoteInfo, cmdSearch } from "./remote
 import { emitRunTelemetryBestEffort } from "./remote/telemetry.js";
 import {
   adapterImplementationStatuses,
+  adapterMockFallbackWarnings,
   runtimeDoctorChecks,
   validateRuntimeRequirements,
 } from "./runtimePreflight.js";
@@ -556,6 +557,7 @@ function cmdDoctor(args: string[]): number {
   let workflow: WorkflowDefinition | null = null;
   let workflowErrors: string[] = [];
   let runtimeErrors: string[] = [];
+  let adapterWarnings: ReturnType<typeof adapterMockFallbackWarnings> = [];
 
   if (workflowPath) {
     try {
@@ -563,6 +565,7 @@ function cmdDoctor(args: string[]): number {
       workflowErrors = validateWorkflow(workflow);
       if (workflowErrors.length === 0) {
         runtimeErrors = validateRuntimeRequirements(workflow);
+        adapterWarnings = adapterMockFallbackWarnings(workflow);
       }
     } catch (err) {
       workflowErrors = [(err as Error).message];
@@ -590,6 +593,7 @@ function cmdDoctor(args: string[]): number {
                 title: workflow.title,
                 errors: workflowErrors,
                 runtimeErrors,
+                adapterWarnings,
               }
             : null,
           baselineErrors,
@@ -627,6 +631,13 @@ function cmdDoctor(args: string[]): number {
       }
     } else {
       console.log("- OK workflow schema and runtime requirements");
+    }
+
+    if (adapterWarnings.length > 0) {
+      console.log("\nAdapter warnings:");
+      for (const warning of adapterWarnings) {
+        console.log(`- ${warning.stepKey}: ${warning.message}`);
+      }
     }
   }
 
@@ -722,6 +733,10 @@ async function cmdRun(filePath: string): Promise<number> {
         failureReason: errors.join("; "),
       });
       return 1;
+    }
+
+    for (const warning of adapterMockFallbackWarnings(workflow)) {
+      process.stderr.write(`⚠ ${warning.stepKey}: ${warning.message}\n`);
     }
 
     const objective = getFlag("--objective");

--- a/src/runtimePreflight.ts
+++ b/src/runtimePreflight.ts
@@ -221,6 +221,49 @@ export function runtimeDoctorChecks(env: NodeJS.ProcessEnv = process.env): Runti
   ];
 }
 
+export interface AdapterMockFallbackWarning {
+  stepKey: string;
+  adapter: AdapterKey;
+  message: string;
+}
+
+/**
+ * Detects a step that explicitly selects a host-backed adapter whose real
+ * execution path is gated behind opt-in payload flags that are not set. Without
+ * those flags the engine routes the step to the mock executor; returning a
+ * message here lets callers warn instead of silently mocking. Returns null when
+ * the step will run as the user expects (default pi-agent, an enabled real
+ * adapter, or an intentional mock/codex selection).
+ */
+export function adapterMockFallbackReason(step: StepDefinition): string | null {
+  if (step.kind !== "task" || !step.taskSpec?.adapterKey) {
+    return null;
+  }
+
+  const adapter = resolveTaskAdapter(step.taskSpec.adapterKey);
+
+  if (adapter === "claude-code" && !shouldUseRealClaudeCode(step)) {
+    return "adapterKey 'claude-code' is set, but the real Claude Code CLI path is off, so the step runs as a mock. Set taskSpec.payload.useRealAdapter: true to drive the real `claude` CLI.";
+  }
+
+  if (adapter === "opencode" && !shouldUseRealOpencode(step)) {
+    return "adapterKey 'opencode' is set, but the real OpenCode CLI path is off, so the step runs as a mock. Set taskSpec.payload.useRealAdapter: true and taskSpec.payload.opencodeSmokeTest: true to drive the real `opencode` CLI.";
+  }
+
+  return null;
+}
+
+export function adapterMockFallbackWarnings(definition: WorkflowDefinition): AdapterMockFallbackWarning[] {
+  const warnings: AdapterMockFallbackWarning[] = [];
+  for (const step of definition.steps) {
+    const message = adapterMockFallbackReason(step);
+    if (message) {
+      warnings.push({ stepKey: step.key, adapter: resolveTaskAdapter(step.taskSpec?.adapterKey), message });
+    }
+  }
+  return warnings;
+}
+
 export function adapterImplementationStatuses(): AdapterImplementationStatus[] {
   return [
     {

--- a/tests/runnerCli.test.ts
+++ b/tests/runnerCli.test.ts
@@ -284,6 +284,53 @@ describe("runner CLI attach API", () => {
     expect(result.stdout).toContain("OK workflow schema and runtime requirements");
   });
 
+  it("warns in doctor when an adapter is selected but will run as mock", async () => {
+    const workflowPath = writeWorkflowFile(
+      {
+        key: "runner-cli-doctor-warn",
+        title: "Runner CLI Doctor Warn",
+        steps: [
+          {
+            key: "review",
+            kind: "task",
+            taskSpec: { adapterKey: "claude-code", payload: { mockResult: "success" } },
+          },
+        ],
+      },
+      "wm-runner-cli-doctor-warn-"
+    );
+
+    const result = await runCommand(["doctor", workflowPath]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Adapter warnings:");
+    expect(result.stdout).toContain("review: adapterKey 'claude-code'");
+    expect(result.stdout).toContain("useRealAdapter: true");
+  });
+
+  it("warns before running when an adapter silently falls back to mock", async () => {
+    const workflowPath = writeWorkflowFile(
+      {
+        key: "runner-cli-run-warn",
+        title: "Runner CLI Run Warn",
+        steps: [
+          {
+            key: "review",
+            kind: "task",
+            validation: { mode: "none", required: false, autoConfirm: true },
+            taskSpec: { adapterKey: "claude-code", payload: { mockResult: "success" } },
+          },
+        ],
+      },
+      "wm-runner-cli-run-warn-"
+    );
+
+    const result = await runCommand(["run", workflowPath, "--auto-confirm-all"]);
+
+    expect(result.stderr).toContain("⚠ review: adapterKey 'claude-code'");
+    expect(result.stderr).toContain("useRealAdapter: true");
+  });
+
   it("prints skill commands in usage", async () => {
     const result = await runCommand(["--help"]);
 

--- a/tests/runtimePreflight.test.ts
+++ b/tests/runtimePreflight.test.ts
@@ -2,8 +2,12 @@ import { describe, expect, it } from "bun:test";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { validateRuntimeRequirements } from "../src/runtimePreflight.ts";
-import type { WorkflowDefinition } from "../src/types.ts";
+import {
+  adapterMockFallbackReason,
+  adapterMockFallbackWarnings,
+  validateRuntimeRequirements,
+} from "../src/runtimePreflight.ts";
+import type { StepDefinition, WorkflowDefinition } from "../src/types.ts";
 
 function workflow(step: WorkflowDefinition["steps"][number]): WorkflowDefinition {
   return {
@@ -131,5 +135,63 @@ describe("runtime preflight", () => {
       'Step review requires claude-code command "claude", but it is not installed or not executable on this host'
     );
     expect(errors).toContain("Step review requires ANTHROPIC_API_KEY for claude-code LLM access");
+  });
+});
+
+describe("adapter mock fallback warnings", () => {
+  const task = (taskSpec: StepDefinition["taskSpec"]): StepDefinition => ({
+    key: "build",
+    kind: "task",
+    taskSpec,
+  });
+
+  it("warns when claude-code is selected without the real-adapter flag", () => {
+    const reason = adapterMockFallbackReason(task({ adapterKey: "claude-code" }));
+    expect(reason).toContain("adapterKey 'claude-code'");
+    expect(reason).toContain("useRealAdapter: true");
+  });
+
+  it("does not warn when claude-code enables the real adapter", () => {
+    expect(adapterMockFallbackReason(task({ adapterKey: "claude-code", payload: { useRealAdapter: true } }))).toBeNull();
+  });
+
+  it("warns when opencode is selected without both real-path flags", () => {
+    const reason = adapterMockFallbackReason(task({ adapterKey: "opencode", payload: { useRealAdapter: true } }));
+    expect(reason).toContain("adapterKey 'opencode'");
+    expect(reason).toContain("opencodeSmokeTest: true");
+  });
+
+  it("does not warn for opencode when both flags are set", () => {
+    expect(
+      adapterMockFallbackReason(
+        task({ adapterKey: "opencode", payload: { useRealAdapter: true, opencodeSmokeTest: true } })
+      )
+    ).toBeNull();
+  });
+
+  it("does not warn for default pi-agent, intentional mock, or codex selections", () => {
+    expect(adapterMockFallbackReason(task({}))).toBeNull();
+    expect(adapterMockFallbackReason(task({ adapterKey: "pi-agent" }))).toBeNull();
+    expect(adapterMockFallbackReason(task({ adapterKey: "mock" }))).toBeNull();
+    expect(adapterMockFallbackReason(task({ adapterKey: "codex" }))).toBeNull();
+  });
+
+  it("does not warn for non-task steps", () => {
+    expect(adapterMockFallbackReason({ key: "gate", kind: "approval" })).toBeNull();
+  });
+
+  it("collects per-step warnings across a workflow", () => {
+    const warnings = adapterMockFallbackWarnings({
+      key: "wf",
+      title: "WF",
+      steps: [
+        { key: "plan", kind: "task", taskSpec: {} },
+        { key: "review", kind: "task", taskSpec: { adapterKey: "claude-code" } },
+      ],
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.stepKey).toBe("review");
+    expect(warnings[0]?.adapter).toBe("claude-code");
   });
 });


### PR DESCRIPTION
## Problem

When a step explicitly set `adapterKey: claude-code` (or `opencode`) but the opt-in real-host flags were absent (`useRealAdapter`, plus `opencodeSmokeTest` for opencode), `engine.ts` silently routed the step to the **mock** executor. A user who assumed the adapter key alone was enough got a fully simulated run with no signal anywhere — the CLI renderer only shows step logs in `--verbose`, so nothing surfaced by default.

## Fix

A shared detector, `adapterMockFallbackReason(step)` in `runtimePreflight.ts`, returns an actionable message for a step that selects a host-backed adapter whose real path is gated off. It's wired into every visible surface:

- **`wfm run`** prints a warning to stderr before execution starts (always visible, like the "Attach API" line).
- **`wfm doctor <workflow>`** reports an `Adapter warnings:` section, plus an `adapterWarnings` field in `--json`. Non-blocking — it does **not** change the exit code.
- **The engine** emits the warning through step hooks (`onStderr`), so it's recorded in runner-API logs/events and shown in verbose output.

The fallback stays a **warning, not an error**, so the deterministic mock authoring/demo flow still runs — including the scaffolded sample, whose `hardening` step uses `claude-code` without flags. `codex` (no real executor exists) and intentional `mock`/default `pi-agent` selections do not warn.

## Example

```
$ wfm doctor ./wf.json
...
Adapter warnings:
- hardening: adapterKey 'claude-code' is set, but the real Claude Code CLI path is off, so the step runs as a mock. Set taskSpec.payload.useRealAdapter: true to drive the real `claude` CLI.

$ wfm run ./wf.json --auto-confirm-all
⚠ hardening: adapterKey 'claude-code' is set, but the real Claude Code CLI path is off, so the step runs as a mock. Set taskSpec.payload.useRealAdapter: true to drive the real `claude` CLI.
```

## Validation

- `bun run lint` — clean
- `bun run build` — clean
- `bun run docs:build` — clean (updated `doc/guide/workflow-schema.md`)
- `bun test tests/runtimePreflight.test.ts tests/runnerCli.test.ts` — 33 pass (9 new: detector unit coverage + doctor/run CLI coverage)
- `bun test tests/engine.test.ts tests/claudeCodeExecutor.test.ts tests/story-workflow.e2e.test.ts` — 44 pass (no routing regressions)
- Manual smoke test of `doctor` and `run` against the scaffold sample — both warn on the `claude-code` step, `codex` stays silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)