### PR TITLE
ci(supabase): stop dep-only changes triggering validate and pin CLI

### DIFF
--- a/.github/workflows/supabase-release.yml
+++ b/.github/workflows/supabase-release.yml
@@ -6,8 +6,6 @@ on:
       - main
     paths:
       - "supabase/**"
-      - "package.json"
-      - "bun.lockb"
       - ".github/workflows/supabase-release.yml"
   workflow_dispatch:
 
@@ -35,7 +33,9 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
         with:
-          version: latest
+          # Pinned: `latest` resolves via the GitHub API and intermittently fails
+          # with "rate limit exceeded". Bump deliberately.
+          version: 2.106.0
 
       - name: Validate Supabase secrets
         run: |

--- a/.github/workflows/supabase-validate.yml
+++ b/.github/workflows/supabase-validate.yml
@@ -6,8 +6,6 @@ on:
       - main
     paths:
       - "supabase/**"
-      - "package.json"
-      - "bun.lockb"
       - ".github/workflows/supabase-validate.yml"
       - ".github/workflows/supabase-release.yml"
   workflow_dispatch:
@@ -36,7 +34,9 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
         with:
-          version: latest
+          # Pinned: `latest` resolves via the GitHub API and intermittently fails
+          # with "rate limit exceeded". Bump deliberately.
+          version: 2.106.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
## Problem

PR #76 surfaced this: the **Supabase Validate** check went red on a PR that only added a runtime dependency. Two issues:

1. **Over-broad trigger.** `supabase-validate.yml` (and `supabase-release.yml`) list `package.json` and `bun.lockb` in their `paths`, so any dependency change runs the supabase jobs even when nothing under `supabase/` changed.
2. **Flaky CLI setup.** Both use `supabase/setup-cli@v1` with `version: latest`, which resolves through the GitHub API and intermittently fails with `Failed to resolve latest Supabase CLI release: rate limit exceeded` — exactly what failed on #76.

## Fix

- Narrow both workflows' `paths` to `supabase/**` plus their own workflow files (drop `package.json` / `bun.lockb`). Dependency-only PRs no longer trigger them; real supabase changes still do, and `workflow_dispatch` remains.
- Pin `supabase/setup-cli` to `2.106.0` (current latest stable) in both workflows, so setup no longer makes a rate-limited "resolve latest" API call. Bump deliberately when needed.

Removing `package.json`/`bun.lockb` is safe for the **release** workflow too: deploys push `supabase/` migrations and functions, which root dependency files don't affect — so those paths only ever caused spurious deploys, never necessary ones.

## Validation

CI-only change (no `src`/tests/docs touched), so the lint/test/build suite doesn't apply. This PR itself edits `supabase-validate.yml`, so the Supabase Validate workflow runs here and exercises the pinned-CLI path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)