### PR TITLE
feat: keep the shell installer in sync with the npm-published version

### DIFF
--- a/apps/remote-registry/src/pages/HomePage.tsx
+++ b/apps/remote-registry/src/pages/HomePage.tsx
@@ -61,8 +61,9 @@ export function HomePage() {
               <Download size={18} strokeWidth={1.75} aria-hidden="true" />
               <h2>Install the CLI, then pull workflows into any repo.</h2>
               <p className="muted">
-                Install `wfm` from npm or the latest GitHub release, then start pulling published workflows
-                without cloning the full repo first.
+                Install `wfm` from npm or the latest GitHub release — the installer script keeps itself in
+                sync with the npm-published version automatically, so both paths always resolve to the same
+                release. Then start pulling published workflows without cloning the full repo first.
               </p>
             </div>
 

--- a/doc/guide/installing.md
+++ b/doc/guide/installing.md
@@ -11,6 +11,8 @@ curl -fsSL https://github.com/navio/workflow-manager/releases/latest/download/wo
 The installer downloads the correct release asset for the current machine and installs the binary into `~/.local/bin` by default.
 If that directory is not already on `PATH`, the installer updates a supported shell profile automatically and prints the exact reload command to run in the current terminal.
 
+Unless you pin a version or override the base URL, the installer resolves the version to download by querying the npm registry for the version currently published as `@workflow-manager/runner`, then downloads the matching GitHub release tag — so the binary you get always matches what's published on npm. If the npm lookup fails, the installer falls back to GitHub's `latest` release and prints a warning.
+
 ## Choose a custom install directory
 
 ```bash
@@ -41,6 +43,7 @@ curl -fsSL https://github.com/navio/workflow-manager/releases/latest/download/wo
 - `WORKFLOW_MANAGER_INSTALL_ARCH`: override architecture detection for testing
 - `WORKFLOW_MANAGER_INSTALL_BASE_URL`: alternate asset base URL for local verification
 - `WORKFLOW_MANAGER_INSTALL_SKIP_SHELL_SETUP`: set to `1` to disable automatic shell profile updates
+- `WORKFLOW_MANAGER_INSTALL_NPM_REGISTRY`: alternate npm registry URL used to resolve the version to install (defaults to `https://registry.npmjs.org/@workflow-manager/runner/latest`); ignored when `WORKFLOW_MANAGER_INSTALL_VERSION` or `WORKFLOW_MANAGER_INSTALL_BASE_URL` is set
 
 ## Supported release binaries
 

--- a/doc/guide/installing.md
+++ b/doc/guide/installing.md
@@ -11,8 +11,6 @@ curl -fsSL https://github.com/navio/workflow-manager/releases/latest/download/wo
 The installer downloads the correct release asset for the current machine and installs the binary into `~/.local/bin` by default.
 If that directory is not already on `PATH`, the installer updates a supported shell profile automatically and prints the exact reload command to run in the current terminal.
 
-Unless you pin a version or override the base URL, the installer resolves the version to download by querying the npm registry for the version currently published as `@workflow-manager/runner`, then downloads the matching GitHub release tag — so the binary you get always matches what's published on npm. If the npm lookup fails, the installer falls back to GitHub's `latest` release and prints a warning.
-
 ## Choose a custom install directory
 
 ```bash
@@ -43,7 +41,6 @@ curl -fsSL https://github.com/navio/workflow-manager/releases/latest/download/wo
 - `WORKFLOW_MANAGER_INSTALL_ARCH`: override architecture detection for testing
 - `WORKFLOW_MANAGER_INSTALL_BASE_URL`: alternate asset base URL for local verification
 - `WORKFLOW_MANAGER_INSTALL_SKIP_SHELL_SETUP`: set to `1` to disable automatic shell profile updates
-- `WORKFLOW_MANAGER_INSTALL_NPM_REGISTRY`: alternate npm registry URL used to resolve the version to install (defaults to `https://registry.npmjs.org/@workflow-manager/runner/latest`); ignored when `WORKFLOW_MANAGER_INSTALL_VERSION` or `WORKFLOW_MANAGER_INSTALL_BASE_URL` is set
 
 ## Supported release binaries
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -123,7 +123,7 @@ else
     npm_registry_url="${WORKFLOW_MANAGER_INSTALL_NPM_REGISTRY:-https://registry.npmjs.org/@workflow-manager/runner/latest}"
     npm_version=''
     if npm_registry_response="$(curl -fsSL --connect-timeout 15 "$npm_registry_url" 2>/dev/null)"; then
-      npm_version="$(printf '%s' "$npm_registry_response" | sed -n 's/.*"version":"\([^"]*\)".*/\1/p' | head -n 1)"
+      npm_version="$(printf '%s' "$npm_registry_response" | tr -d ' \t\n\r' | sed -n 's/.*"version":"\([^"]*\)".*/\1/p' | head -n 1)"
     fi
 
     if [ -n "$npm_version" ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -117,7 +117,23 @@ esac
 if [ -n "${WORKFLOW_MANAGER_INSTALL_BASE_URL:-}" ]; then
   download_url="${WORKFLOW_MANAGER_INSTALL_BASE_URL%/}/${asset_name}"
 else
-  version="${WORKFLOW_MANAGER_INSTALL_VERSION:-latest}"
+  if [ -n "${WORKFLOW_MANAGER_INSTALL_VERSION:-}" ]; then
+    version="$WORKFLOW_MANAGER_INSTALL_VERSION"
+  else
+    npm_registry_url="${WORKFLOW_MANAGER_INSTALL_NPM_REGISTRY:-https://registry.npmjs.org/@workflow-manager/runner/latest}"
+    npm_version=''
+    if npm_registry_response="$(curl -fsSL --connect-timeout 15 "$npm_registry_url" 2>/dev/null)"; then
+      npm_version="$(printf '%s' "$npm_registry_response" | sed -n 's/.*"version":"\([^"]*\)".*/\1/p' | head -n 1)"
+    fi
+
+    if [ -n "$npm_version" ]; then
+      version="v${npm_version}"
+    else
+      printf 'warning: could not resolve latest version from npm; falling back to GitHub latest release\n' >&2
+      version='latest'
+    fi
+  fi
+
   if [ "$version" = 'latest' ]; then
     download_url="https://github.com/${repo_owner}/${repo_name}/releases/latest/download/${asset_name}"
   else

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -272,6 +272,68 @@ describe("remote installer", () => {
     }
   });
 
+  it("resolves the version from a pretty-printed npm registry response", async () => {
+    const installDir = makeTempDir("wm-install-dir-");
+    const npmRegistryServer = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(JSON.stringify({ name: "@workflow-manager/runner", version: "8.8.8" }, null, 2), {
+          headers: { "Content-Type": "application/json" },
+        });
+      },
+    });
+
+    try {
+      const result = await runInstallScript({
+        ...process.env,
+        PATH: process.env.PATH ?? "",
+        WORKFLOW_MANAGER_INSTALL_NPM_REGISTRY: `http://127.0.0.1:${npmRegistryServer.port}/`,
+        WORKFLOW_MANAGER_INSTALL_DIR: installDir,
+        WORKFLOW_MANAGER_INSTALL_OS: "linux",
+        WORKFLOW_MANAGER_INSTALL_ARCH: "x86_64",
+      });
+
+      expect(result.stdout).toContain(
+        "Downloading wfm from https://github.com/navio/workflow-manager/releases/download/v8.8.8/wfm-linux-x64",
+      );
+      expect(result.stderr).not.toContain("could not resolve latest version from npm");
+    } finally {
+      await npmRegistryServer.stop(true);
+    }
+  });
+
+  it("falls back to the GitHub latest release when the npm registry response has no version field", async () => {
+    const installDir = makeTempDir("wm-install-dir-");
+    const npmRegistryServer = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(JSON.stringify({ error: "not found" }), {
+          headers: { "Content-Type": "application/json" },
+        });
+      },
+    });
+
+    try {
+      const result = await runInstallScript({
+        ...process.env,
+        PATH: process.env.PATH ?? "",
+        WORKFLOW_MANAGER_INSTALL_NPM_REGISTRY: `http://127.0.0.1:${npmRegistryServer.port}/`,
+        WORKFLOW_MANAGER_INSTALL_DIR: installDir,
+        WORKFLOW_MANAGER_INSTALL_OS: "linux",
+        WORKFLOW_MANAGER_INSTALL_ARCH: "x86_64",
+      });
+
+      expect(result.stderr).toContain(
+        "warning: could not resolve latest version from npm; falling back to GitHub latest release",
+      );
+      expect(result.stdout).toContain(
+        "Downloading wfm from https://github.com/navio/workflow-manager/releases/latest/download/wfm-linux-x64",
+      );
+    } finally {
+      await npmRegistryServer.stop(true);
+    }
+  });
+
   it("falls back to the GitHub latest release when the npm registry lookup fails", async () => {
     const installDir = makeTempDir("wm-install-dir-");
     const npmRegistryServer = Bun.serve({

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -241,4 +241,95 @@ describe("remote installer", () => {
       await server.stop(true);
     }
   });
+
+  it("resolves the download version from the npm registry when no version or base URL is pinned", async () => {
+    const installDir = makeTempDir("wm-install-dir-");
+    const npmRegistryServer = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(JSON.stringify({ name: "@workflow-manager/runner", version: "9.9.9" }), {
+          headers: { "Content-Type": "application/json" },
+        });
+      },
+    });
+
+    try {
+      const result = await runInstallScript({
+        ...process.env,
+        PATH: process.env.PATH ?? "",
+        WORKFLOW_MANAGER_INSTALL_NPM_REGISTRY: `http://127.0.0.1:${npmRegistryServer.port}/`,
+        WORKFLOW_MANAGER_INSTALL_DIR: installDir,
+        WORKFLOW_MANAGER_INSTALL_OS: "linux",
+        WORKFLOW_MANAGER_INSTALL_ARCH: "x86_64",
+      });
+
+      expect(result.stdout).toContain(
+        "Downloading wfm from https://github.com/navio/workflow-manager/releases/download/v9.9.9/wfm-linux-x64",
+      );
+      expect(result.stderr).not.toContain("could not resolve latest version from npm");
+    } finally {
+      await npmRegistryServer.stop(true);
+    }
+  });
+
+  it("falls back to the GitHub latest release when the npm registry lookup fails", async () => {
+    const installDir = makeTempDir("wm-install-dir-");
+    const npmRegistryServer = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response("internal error", { status: 500 });
+      },
+    });
+
+    try {
+      const result = await runInstallScript({
+        ...process.env,
+        PATH: process.env.PATH ?? "",
+        WORKFLOW_MANAGER_INSTALL_NPM_REGISTRY: `http://127.0.0.1:${npmRegistryServer.port}/`,
+        WORKFLOW_MANAGER_INSTALL_DIR: installDir,
+        WORKFLOW_MANAGER_INSTALL_OS: "linux",
+        WORKFLOW_MANAGER_INSTALL_ARCH: "x86_64",
+      });
+
+      expect(result.stderr).toContain(
+        "warning: could not resolve latest version from npm; falling back to GitHub latest release",
+      );
+      expect(result.stdout).toContain(
+        "Downloading wfm from https://github.com/navio/workflow-manager/releases/latest/download/wfm-linux-x64",
+      );
+    } finally {
+      await npmRegistryServer.stop(true);
+    }
+  });
+
+  it("skips the npm registry lookup when a version is explicitly pinned", async () => {
+    const installDir = makeTempDir("wm-install-dir-");
+    const npmRegistryServer = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(JSON.stringify({ name: "@workflow-manager/runner", version: "9.9.9" }), {
+          headers: { "Content-Type": "application/json" },
+        });
+      },
+    });
+
+    try {
+      const result = await runInstallScript({
+        ...process.env,
+        PATH: process.env.PATH ?? "",
+        WORKFLOW_MANAGER_INSTALL_VERSION: "v1.2.3",
+        WORKFLOW_MANAGER_INSTALL_NPM_REGISTRY: `http://127.0.0.1:${npmRegistryServer.port}/`,
+        WORKFLOW_MANAGER_INSTALL_DIR: installDir,
+        WORKFLOW_MANAGER_INSTALL_OS: "linux",
+        WORKFLOW_MANAGER_INSTALL_ARCH: "x86_64",
+      });
+
+      expect(result.stdout).toContain(
+        "Downloading wfm from https://github.com/navio/workflow-manager/releases/download/v1.2.3/wfm-linux-x64",
+      );
+      expect(result.stdout).not.toContain("v9.9.9");
+    } finally {
+      await npmRegistryServer.stop(true);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- `scripts/install.sh` now resolves the version to download by querying the npm registry (`@workflow-manager/runner`) instead of blindly trusting GitHub's `latest` release pointer, so the curl-installer and `npm install -g @workflow-manager/runner` paths always resolve to the same build.
- New `WORKFLOW_MANAGER_INSTALL_NPM_REGISTRY` override (default `https://registry.npmjs.org/@workflow-manager/runner/latest`), tolerant of pretty-printed JSON responses.
- Falls back non-fatally to the old GitHub-`latest` behavior (with a stderr warning) if the npm lookup fails or returns no parseable version.
- Explicit `WORKFLOW_MANAGER_INSTALL_VERSION` pins and `WORKFLOW_MANAGER_INSTALL_BASE_URL` overrides are unchanged — both still bypass the npm lookup entirely.
- Updated the "Install locally" copy on the remote-registry website (`apps/remote-registry/src/pages/HomePage.tsx`) to reflect that the two install paths stay version-synced.

## Related
- Homebrew was out of scope — no formula/tap exists in this repo today.
- Docs describing this behavior (`doc/guide/installing.md`) ship in the sibling PR: workflow-manager/07-13-26/release-0-8-0-docs. No dependency for CI/merge — this PR is self-contained; the docs PR just documents behavior that lands here.

## Test plan
- [x] `bun run lint`
- [x] `bun test tests/installer.test.ts` (9 pass, including new coverage for npm-version resolution, pretty-printed JSON, missing-version fallback, and explicit-pin bypass)
- [x] `bun run test:unit` (209 pass)
- [x] `bun run build`
- [x] `bun run remote-registry:test`
- [x] `bun run remote-registry:build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuRttyTnLsFBtXys44jjU6