### PR TITLE
docs: announce v0.8.0 agent-authored workflows with a new News section

### DIFF
--- a/doc/.vitepress/config.mts
+++ b/doc/.vitepress/config.mts
@@ -7,6 +7,7 @@ export default defineConfig({
   themeConfig: {
     nav: [
       { text: "Home", link: "/" },
+      { text: "News", link: "/news/" },
       { text: "Install", link: "/guide/installing" },
       { text: "Getting Started", link: "/guide/getting-started" },
       { text: "How It Works", link: "/guide/how-it-works" },
@@ -22,6 +23,13 @@ export default defineConfig({
       { text: "Workflow Examples", link: "/guide/workflow-examples" }
     ],
     sidebar: [
+      {
+        text: "News",
+        items: [
+          { text: "All posts", link: "/news/" },
+          { text: "Agent-Authored Workflows (v0.8.0)", link: "/news/2026-07-13-agent-authored-workflows" }
+        ]
+      },
       {
         text: "Guide",
         items: [

--- a/doc/guide/installing.md
+++ b/doc/guide/installing.md
@@ -2,6 +2,8 @@
 
 `wfm` ships as a prebuilt release binary for macOS arm64 and Linux x64, and the installer also creates a `workflow-manager` alias.
 
+When no version is pinned via `WORKFLOW_MANAGER_INSTALL_VERSION`, the installer looks up the currently-published npm version of `@workflow-manager/runner` and downloads the matching GitHub release asset, instead of blindly trusting GitHub's "latest" pointer. This keeps the npm and GitHub-binary install paths in sync. If the npm lookup fails, the installer falls back to GitHub's "latest" release pointer with a warning.
+
 ## Install from GitHub Releases
 
 ```bash
@@ -35,6 +37,7 @@ curl -fsSL https://github.com/navio/workflow-manager/releases/latest/download/wo
 
 - `WORKFLOW_MANAGER_INSTALL_DIR`: target directory for the installed `wfm` binary
 - `WORKFLOW_MANAGER_INSTALL_VERSION`: release tag to download instead of `latest`
+- `WORKFLOW_MANAGER_INSTALL_NPM_REGISTRY`: npm registry URL used to look up the currently-published version when no version is pinned (default `https://registry.npmjs.org/@workflow-manager/runner/latest`), overridable for testing or mirrors
 - `WORKFLOW_MANAGER_INSTALL_BIN_NAME`: alternate filename for the installed binary
 - `WORKFLOW_MANAGER_INSTALL_ALIAS_NAME`: alternate alias name to install alongside the main binary
 - `WORKFLOW_MANAGER_INSTALL_OS`: override platform detection for testing

--- a/doc/index.md
+++ b/doc/index.md
@@ -28,6 +28,7 @@ It is designed for agentic and human-in-the-loop execution where each step can h
 
 ## Quick links
 
+- [News: Agent-Authored Workflows (v0.8.0)](/news/2026-07-13-agent-authored-workflows)
 - [Installing the CLI](/guide/installing)
 - [Getting Started](/guide/getting-started)
 - [Workflow Manager UI](https://workflow-manager-ui.netlify.app)

--- a/doc/news/2026-07-13-agent-authored-workflows.md
+++ b/doc/news/2026-07-13-agent-authored-workflows.md
@@ -1,0 +1,31 @@
+# Agent-Authored Workflows (v0.8.0)
+
+*2026-07-13*
+
+v0.8.0 lets you author and validate `wfm` workflows collaboratively with a coding agent instead of hand-writing frontmatter from scratch. Describe a repeatable task in plain language, and the agent elicits success criteria, decomposes it into chronological steps, picks a quality gate per step, scaffolds the file, and validates it — then can drive the run and narrate progress back to you.
+
+## What's new
+
+- **Agent validation for steps** — `validation.mode: agent` runs a second agent call against a step's output and maps its verdict onto the engine's existing QA routing (`PROCEED`, `RETRY_CURRENT`, `ROLLBACK_PREVIOUS`, `RESTART_ALL`), so a step can be checked against phrased criteria (tests pass, diff stays in scope) without a human in the loop.
+- **`attach-client` CLI + session-file handoff** — `wfm run <file> --session-file <path>` writes attach connection details as soon as a run starts and rewrites the file with the final status when it ends, so an agent can start a run in the background, poll it with `wfm status` / `wfm logs` / `wfm events`, and keep talking to you in between.
+- **`wfm scaffold --template agent-validated`** — drops a three-step example workflow (agent-validated task → approval → finalize) as a starting point to edit in place.
+- **Bundled `workflow-author` skill** — `wfm skill install workflow-author` installs the skill that teaches an agent the full authoring loop: eliciting criteria, decomposing steps, choosing gates, scaffolding, validating, dry-running, and narrating a run.
+- **Skills embedded in compiled binaries** — bundled skills (including `workflow-author`) are now embedded directly into compiled binaries at build time, so `wfm skill install` works out of the box without a separate skills download.
+
+Read the full guide at [Authoring Workflows With an Agent](/guide/authoring-with-an-agent) for the end-to-end loop, including the approval-gate schema gotcha and a worked session-file transcript.
+
+## Also recent: Terminal UI (v0.7.0)
+
+The previous release, v0.7.0, added a full-screen terminal UI for watching a run live: `wfm run <file> --ui` replaces the default scrolling output with a two-pane view — a step list on the left, streaming activity for the selected step on the right — with key bindings for approvals, resuming, and cancelling. See [Terminal UI](/guide/terminal-ui) for the layout and key bindings.
+
+## Installing this version
+
+```bash
+npm install -g @workflow-manager/runner
+```
+
+```bash
+curl -fsSL https://github.com/navio/workflow-manager/releases/latest/download/workflow-manager-installer.sh | bash
+```
+
+Both install paths now stay version-synced: when no version is pinned, the shell installer looks up the currently-published npm version and downloads the matching GitHub release asset, so `npm install -g @workflow-manager/runner` and the curl installer always resolve to the same build. See [Installing the CLI](/guide/installing) for the full set of environment overrides.

--- a/doc/news/index.md
+++ b/doc/news/index.md
@@ -1,0 +1,5 @@
+# News
+
+Release notes and announcements for `workflow-manager`.
+
+- **2026-07-13** — [Agent-Authored Workflows (v0.8.0)](/news/2026-07-13-agent-authored-workflows) — author and validate workflows collaboratively with an agent, plus session-file handoff, `scaffold --template agent-validated`, and a bundled `workflow-author` skill.


### PR DESCRIPTION
## Summary
- Adds a "News" section to the docs site (`doc/news/`) with an announcement post covering the last week's merged work:
  - **v0.8.0** — agent-authored workflows: agent validation for steps, `attach-client` CLI + session-file handoff, `wfm scaffold --template agent-validated`, the bundled `workflow-author` skill, and skills embedded directly into compiled binaries.
  - **v0.7.0** — full-screen terminal UI (`wfm run --ui`), covered briefly for continuity.
- Wires the new pages into `doc/.vitepress/config.mts` nav/sidebar and links the post from `doc/index.md`.
- Updates `doc/guide/installing.md` to document the npm-registry version-sync behavior of `scripts/install.sh` (new `WORKFLOW_MANAGER_INSTALL_NPM_REGISTRY` override) and its GitHub-`latest` fallback.

## ⚠️ Merge-order note
The installer behavior described in `doc/guide/installing.md` and the news post ships in the sibling PR #108 (`workflow-manager/07-13-26/npm-synced-install`), not in this diff. **Merge #108 before (or together with) this PR** — this docs-only PR auto-deploys to the public GitHub Pages site on merge (`deploy-docs.yml`), so merging it first would describe installer behavior that doesn't exist on `main` yet.

## Test plan
- [x] `bun run lint`
- [x] `bun test` (360 pass, 2 pre-existing skips)
- [x] `bun run build`
- [x] `bun run docs:build`
- [x] Independent code review confirmed all factual claims (routing verbs, `--session-file` behavior, scaffold template, bundled-skills embedding, v0.7.0 TUI summary) against source; no broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuRttyTnLsFBtXys44jjU6